### PR TITLE
Add parser support for indentation level in unordered list items

### DIFF
--- a/Parser/MarkdownParse.wl
+++ b/Parser/MarkdownParse.wl
@@ -364,7 +364,5 @@ MarkdownParse[file_String]/;FileExistsQ[file]:=Block[
 (* ::Chapter:: *)
 (*End Package*)
 
-
 End[]
-Protect["MarkdownParse`*"];
 EndPackage[]

--- a/Parser/MarkdownParse.wl
+++ b/Parser/MarkdownParse.wl
@@ -17,7 +17,7 @@ MarkdownParse::usage="MarkdownParse[\*StyleBox[\"file . md\",\"TI\"]] Reads in m
 MarkdownElement::usage="Represents an element in Symbolic Markdown"
 $sampleStrings::usage="A set of strings used for testing"
 $MarkdownParsePrimitives::usage="A set of patterns for markdown primitives"
-
+ExtractMarkdownFootnoteURL
 Begin["Private`"]
 
 
@@ -353,7 +353,7 @@ MarkdownParse[file_String]/;FileExistsQ[file]:=Block[
 	(* Repeatedly apply the parser to each line until the expression doesn't change *)
 	parsedLines=(FixedPoint[MarkdownParser,#]&/@lines);
 	(* Replace footnote references with their respective URLs *)
-	footnoteCheck=(parsedLines /. MarkdownElement["FootnoteReference", {ref_}]:>First@ExtractMarkdownFootnoteURL[ref,footFile]);
+	footnoteCheck=Replace[parsedLines, MarkdownElement["FootnoteReference", {ref_Integer}] :> First@ExtractMarkdownFootnoteURL[ref,footFile], Infinity];
 	(* Get rid of the footnote residue *)
 	parse1=If[StringQ[#]\[And]StringMatchQ[$footnote][#],StringReplace[$footnote-> "(wasfootnote)"][#],#]&/@footnoteCheck;
 	parse1clean=DeleteCases["(wasfootnote)"][parse1]

--- a/Parser/MarkdownParse.wl
+++ b/Parser/MarkdownParse.wl
@@ -103,7 +103,7 @@ mdpFootnote=RegularExpression["(?ms)(?:\\A|^|\\s)\\[(.+?)\\]\\[(\\d+?)\\]"]:>Mar
 (* mdpOrderedListItem=RegularExpression["(?ms)(?:\\A|^|\\s+)(\\d+)\\.\\s(.+)\\z"]:> MarkdownElement["ItemNumbered",{ToExpression["$1"]},MarkdownParser["$2"]] *)
 mdpOrderedListItem=(RegularExpression["(\\A|^|\\s+|\\t+)(\\d\\.)+ (.*)"]) :>With[
 	{type = GetIndentationType["$1"]},
-	MarkdownElement["Item", <|"IndentationLevel" -> GetIndentationLevel["$1", type],"IndentationType" -> type, "Content" -> "$3"|> ]
+	MarkdownElement["Item", <|"Type" -> "Ordered", "IndentationLevel" -> GetIndentationLevel["$1", type],"IndentationType" -> type, "Content" -> "$3"|> ]
 	]
 
 
@@ -129,7 +129,7 @@ GetIndentationType[s_String] := "Whitespace"
 
 mdpUnorderedItem = (RegularExpression["(\\A|^|\\s+|\\t+)[\\*\\-\\+] (.*)"]) :> With[
 	{type = GetIndentationType["$1"]},
-	MarkdownElement["Item", <|"IndentationLevel" -> GetIndentationLevel["$1", type],"IndentationType" -> type, "Content" -> MarkdownParser["$2"]|> ]
+	MarkdownElement["Item", <|"Type" -> "Unordered", "IndentationLevel" -> GetIndentationLevel["$1", type],"IndentationType" -> type, "Content" -> MarkdownParser["$2"]|> ]
 	];
 
 

--- a/Parser/MarkdownParse.wl
+++ b/Parser/MarkdownParse.wl
@@ -13,15 +13,11 @@
 
 
 BeginPackage["MarkdownParse`"]
-(* \[DownArrow] Allow Refresh of Definitions on Get call \[DownArrow] *)
-Unprotect["MarkdownParse`*"];
-ClearAll["MarkdownParse`*"];
-ClearAll["MarkdownParse`Private`*"];
-(* \[UpArrow] Can be removed in Production             \[UpArrow] *)
 MarkdownParse::usage="MarkdownParse[\*StyleBox[\"file . md\",\"TI\"]] Reads in markdown \*StyleBox[\"file . md\",\"TI\"], and parses to a list of nested MarkdownElements and text"
 MarkdownElement::usage="Represents an element in Symbolic Markdown"
 $sampleStrings::usage="A set of strings used for testing"
 $MarkdownParsePrimitives::usage="A set of patterns for markdown primitives"
+
 Begin["Private`"]
 
 
@@ -104,7 +100,11 @@ mdpFootnote=RegularExpression["(?ms)(?:\\A|^|\\s)\\[(.+?)\\]\\[(\\d+?)\\]"]:>Mar
 (*OrderedItem*)
 
 (* TODO: Add indentation support for ordered items *)
-mdpOrderedListItem=RegularExpression["(?ms)(?:\\A|^|\\s+)(\\d+)\\.\\s(.+)\\z"]:> MarkdownElement["ItemNumbered",{ToExpression["$1"]},MarkdownParser["$2"]]
+(* mdpOrderedListItem=RegularExpression["(?ms)(?:\\A|^|\\s+)(\\d+)\\.\\s(.+)\\z"]:> MarkdownElement["ItemNumbered",{ToExpression["$1"]},MarkdownParser["$2"]] *)
+mdpOrderedListItem=(RegularExpression["(\\A|^|\\s+|\\t+)(\\d\\.)+ (.*)"]) :>With[
+	{type = GetIndentationType["$1"]},
+	MarkdownElement["Item", <|"IndentationLevel" -> GetIndentationLevel["$1", type],"IndentationType" -> type, "Content" -> "$3"|> ]
+	]
 
 
 (* ::Subsubsection::Closed:: *)

--- a/Parser/MarkdownParserDemo.nb
+++ b/Parser/MarkdownParserDemo.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    207034,       4498]
-NotebookOptionsPosition[    203521,       4433]
-NotebookOutlinePosition[    204007,       4451]
-CellTagsIndexPosition[    203964,       4448]
+NotebookDataLength[    248845,       5285]
+NotebookOptionsPosition[    245100,       5216]
+NotebookOutlinePosition[    245587,       5234]
+CellTagsIndexPosition[    245544,       5231]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -46,7 +46,7 @@ Cell["Quit the kernel", "CodeText",
 
 Cell[BoxData["Quit"], "Input",
  CellChangeTimes->{{3.817239754310732*^9, 3.8172397548456573`*^9}},
- CellLabel->"In[32]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+ CellLabel->"In[5]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
 
 Cell["Install the packages again from the Menu:", "Text",
  CellChangeTimes->{{3.8174165987397127`*^9, 
@@ -196,13 +196,21 @@ Cell[BoxData[
          RowBox[{"{", "$2", "}"}]}], "]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\"\<ItemNumbered\>\"", ",", 
-       RowBox[{"{", "$1", "}"}], ",", "\"\<$2\>\""}], "]"}]},
+      RowBox[{"\"\<Item\>\"", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\"\<Type\>\"", "\[Rule]", "\"\<Ordered\>\""}], ",", 
+         RowBox[{"\"\<IndentationLevel\>\"", "\[Rule]", "1"}], ",", 
+         RowBox[{"\"\<IndentationType\>\"", "\[Rule]", "\"\<Whitespace\>\""}],
+          ",", 
+         RowBox[{"\"\<Content\>\"", "\[Rule]", "\"\<$3\>\""}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"\"\<Item\>\"", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\"\<Type\>\"", "\[Rule]", "\"\<Unordered\>\""}], ",", 
          RowBox[{"\"\<IndentationLevel\>\"", "\[Rule]", "1"}], ",", 
          RowBox[{"\"\<IndentationType\>\"", "\[Rule]", "\"\<Whitespace\>\""}],
           ",", 
@@ -257,8 +265,9 @@ Cell[BoxData[
    3.817346450554831*^9, 3.817346621485446*^9, 3.81734675276777*^9, 
    3.817389589946957*^9, 3.817423982038066*^9, 3.8397853572118587`*^9, {
    3.839785419382757*^9, 3.8397854364402733`*^9}, {3.839785527027009*^9, 
-   3.839785540844495*^9}, 3.839786014047813*^9, 3.8397862448168993`*^9},
- CellLabel->"Out[3]=",ExpressionUUID->"9d30d1e1-3b38-4327-b7fa-5f15a0c5141e"]
+   3.839785540844495*^9}, 3.839786014047813*^9, 3.8397862448168993`*^9, 
+   3.845226378341282*^9},
+ CellLabel->"Out[3]=",ExpressionUUID->"3b4e9d5f-2ca3-4524-b7a9-f0828e41a3fe"]
 }, Open  ]]
 }, Open  ]],
 
@@ -289,9 +298,10 @@ Cell[CellGroupData[{
 
 Cell[BoxData[
  RowBox[{"Import", "[", 
-  RowBox[{"filePath", ",", "\"\<String\>\""}], "]"}]], "Input",
- CellChangeTimes->{{3.839786671641347*^9, 3.8397867032127323`*^9}},
- CellLabel->"In[19]:=",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
+  RowBox[{"filePath", ",", "\"\<Text\>\""}], "]"}]], "Input",
+ CellChangeTimes->{{3.839786671641347*^9, 3.8397867032127323`*^9}, {
+  3.845226422574849*^9, 3.845226424824779*^9}},
+ CellLabel->"In[6]:=",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
 
 Cell[BoxData["\<\"# An exhibit of Markdown\\n\\nThis note demonstrates some \
 of what [Markdown][1] is capable of doing.\\n\\n_Note: Feel free to play with \
@@ -301,36 +311,41 @@ is the basic block of Markdown. A paragraph is what text will turn into when \
 there is no reason it should become anything else.\\n\\nBlank lines separate \
 paragraphs. Markdown supports _italic_ and **bold** formatting.\\n\\nLines \
 can have nested styling as well, like _a **bold** in an italic_.\\n\\n## \
-Lists\\n\\n### Ordered list\\n\\n1. Item 1\\n2. A second item\\n3. Number \
-3\\n4. \[AHat]\.85\[Sterling]\\n\\n_Note: the fourth item uses the Unicode \
-character for [Roman numeral four][2]._\\n\\n### Unordered list\\n\\n* An \
-item\\n* Another item\\n* Yet another item\\n* And there's more...\\n\\n## \
-Paragraph modifiers\\n\\n### Code block\\n\\n    Code blocks are useful for \
-people who look at code or for clarity of plain text content. As you can see, \
-it uses a fixed-width font.\\n\\nYou can also make `inline code` to add \
-insert code block formatting anywhere.\\n\\n### Quote\\n\\n> Here is a quote. \
-What this is should be self explanatory. Quotes are automatically indented \
-when they are used.\\n\\n## Headings\\n\\nMarkdown supports six levels of \
-headings; corresponding with the six levels of HTML headings. You've probably \
-noticed them already in the page. Each level down uses one more hash \
-character.\\n\\n### Headings _can_ also contain **formatting**\\n\\n### They \
-can even contain `inline code`\\n\\nOf course, demonstrating what headings \
-look like messes up the structure of the page.\\n\\nI don't recommend using \
-more than three or four levels of headings here, because, when you're \
-smallest heading isn't too small, and you're largest heading isn't too big, \
-and you want each size up to look noticeably larger and more important, there \
-aren't any other sizes to choose from.\\n\\n## LaTex\\n\\nLaTex is also \
-supported:\\n\\n* inline\\n\\n\\\\(a^2 + b^2 = c^2\\\\)\\n\\n$ a^2 + b^2 = \
-c^2 $\\n\\n* presented\\n\\n\\\\[ a^n + b^n = c^n \\\\]\\n\\n$$ a^2 + b^2 = \
-c^2 $$\\n\\n\\n## URLs\\n\\nAdd hyperlinks in the following ways:\\n\\n* A \
-named link to [MarkItDown][3]. The easiest way to do these is to select what \
-you want to make a link and hit `Ctrl+L`.\\n* Another named link to \
-[MarkItDown](http://www.markitdown.net/)\\n* Sometimes you want the URL : \
-<http://www.markitdown.net/>.\\n\\n## Horizontal rule\\n\\nA horizontal rule \
-is a dividing line drawn across the page, useful for separating blocks of \
-text.\\n\\n---\\n\\n## Tables\\n\\nMarkdown | Less | Pretty\\n--- | --- | ---\
-\\n*Still* | `renders` | **nicely**\\n1 | 2 | 3\\n\\n## Images\\n\\nMarkdown \
-can also contain images.\\n![Streetview of Palm Trees by Brandon \
+Lists\\n\\n### Ordered list with Tabs\\n\\n1. Item 1\\n2. A second item\\n3. \
+Number 3\\n4. \:2163\\n\\t5. A nested ordered item\\n\\n### Ordered list with \
+Spaces\\n\\n1. First item\\n  2. First item's subitem\\n  3. First item's 2nd \
+subitem\\n    4. 2nd item's subitem\\n\\n_Note: the fourth item uses the \
+Unicode character for [Roman numeral four][2]._\\n\\n### Unordered \
+list\\n\\n* An item\\n* Another item\\n* Yet another item\\n\\t* A nested \
+unordered item with tabs\\n* And there's more...\\n\\n* unordered list with \
+spaces\\n  * list item with space indentation\\n    * another list item with \
+space indentation\\n\\n## Paragraph modifiers\\n\\n### Code block\\n\\n    \
+Code blocks are useful for people who look at code or for clarity of plain \
+text content. As you can see, it uses a fixed-width font.\\n\\nYou can also \
+make `inline code` to add insert code block formatting anywhere.\\n\\n### \
+Quote\\n\\n> Here is a quote. What this is should be self explanatory. Quotes \
+are automatically indented when they are used.\\n\\n## Headings\\n\\nMarkdown \
+supports six levels of headings; corresponding with the six levels of HTML \
+headings. You've probably noticed them already in the page. Each level down \
+uses one more hash character.\\n\\n### Headings _can_ also contain \
+**formatting**\\n\\n### They can even contain `inline code`\\n\\nOf course, \
+demonstrating what headings look like messes up the structure of the page.\\n\
+\\nI don't recommend using more than three or four levels of headings here, \
+because, when you're smallest heading isn't too small, and you're largest \
+heading isn't too big, and you want each size up to look noticeably larger \
+and more important, there aren't any other sizes to choose from.\\n\\n## \
+LaTex\\n\\nLaTeX is also supported:\\n\\n* inline\\n\\n\\\\(a^2 + b^2 = c^2\\\
+\\)\\n\\n$ a^2 + b^2 = c^2 $\\n\\n* presented\\n\\n\\\\[ a^n + b^n = c^n \
+\\\\]\\n\\n$$ a^2 + b^2 = c^2 $$\\n\\n\\n## URLs\\n\\nAdd hyperlinks in the \
+following ways:\\n\\n* A named link to [MarkItDown][3]. The easiest way to do \
+these is to select what you want to make a link and hit `Ctrl+L`.\\n* Another \
+named link to [MarkItDown](http://www.markitdown.net/)\\n* Sometimes you want \
+the URL : <http://www.markitdown.net/>.\\n\\n## Horizontal rule\\n\\nA \
+horizontal rule is a dividing line drawn across the page, useful for \
+separating blocks of text.\\n\\n---\\n\\n## Tables\\n\\nMarkdown | Less | \
+Pretty\\n--- | --- | ---\\n*Still* | `renders` | **nicely**\\n1 | 2 | \
+3\\n\\n## Images\\n\\nMarkdown can also contain images.\\n![Streetview of \
+Palm Trees by Brandon \
 Erlinger-Ford](https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
 ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
 format&fit=crop&w=564&q=80)\\n\\n## Last\\n\\nThere's actually a lot more to \
@@ -341,10 +356,11 @@ platforms.\\n\\n\\n  [1]: http://daringfireball.net/projects/markdown/\\n  \
 [2]: http://www.fileformat.info/info/unicode/char/2163/index.htm\\n  [3]: \
 http://www.markitdown.net/\\n  [4]: \
 http://daringfireball.net/projects/markdown/basics\\n  [5]: \
-http://daringfireball.net/projects/markdown/syntax\\n\"\>"], "Output",
- CellChangeTimes->{{3.839786672681287*^9, 3.839786703609291*^9}},
- CellLabel->"Out[19]=",ExpressionUUID->"1c788981-27b2-4fe6-a8a9-38507ecb363b"]
-}, Open  ]],
+http://daringfireball.net/projects/markdown/syntax\"\>"], "Output",
+ CellChangeTimes->{{3.839786672681287*^9, 3.839786703609291*^9}, {
+  3.8452264115314407`*^9, 3.845226425375347*^9}},
+ CellLabel->"Out[6]=",ExpressionUUID->"35f09d72-a78d-43d5-8a17-d90e59057af6"]
+}, Closed]],
 
 Cell[BoxData[
  RowBox[{
@@ -355,7 +371,7 @@ Cell[BoxData[
    3.8171704049186897`*^9}, 3.8172358431384687`*^9, {3.817240946833456*^9, 
    3.81724094888334*^9}, 3.8172413585269203`*^9, {3.81734384974724*^9, 
    3.817343850827291*^9}},
- CellLabel->"In[5]:=",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
+ CellLabel->"In[9]:=",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
 
 Cell[CellGroupData[{
 
@@ -364,7 +380,7 @@ Cell[BoxData[
   RowBox[{"mdp", ",", 
    RowBox[{"Frame", "\[Rule]", "All"}]}], "]"}]], "Input",
  CellChangeTimes->{{3.817333311218748*^9, 3.817333316916204*^9}},
- CellLabel->"In[6]:=",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
+ CellLabel->"In[11]:=",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
 
 Cell[BoxData[
  TagBox[GridBox[{
@@ -417,23 +433,109 @@ should become anything else.\"\>"},
       RowBox[{"\<\"H2\"\>", ",", "\<\"Lists\"\>"}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"H3\"\>", ",", "\<\"Ordered list\"\>"}], "]"}]},
+      RowBox[{"\<\"H3\"\>", ",", "\<\"Ordered list with Tabs\"\>"}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"ItemNumbered\"\>", ",", 
-       RowBox[{"{", "1", "}"}], ",", "\<\"Item 1\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Ordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"Item 1\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"ItemNumbered\"\>", ",", 
-       RowBox[{"{", "2", "}"}], ",", "\<\"A second item\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Ordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"A second item\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"ItemNumbered\"\>", ",", 
-       RowBox[{"{", "3", "}"}], ",", "\<\"Number 3\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Ordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"Number 3\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"ItemNumbered\"\>", ",", 
-       RowBox[{"{", "4", "}"}], ",", "\<\"\:2163\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Ordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"\:2163\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Ordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "1"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "\<\"Tabs\"\>"}], ",", 
+         
+         RowBox[{"\<\"Content\"\>", 
+          "\[Rule]", "\<\"A nested ordered item\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"H3\"\>", ",", "\<\"Ordered list with Spaces\"\>"}], 
+      "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Ordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"First item\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Ordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "1"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "\<\"Whitespace\"\>"}],
+          ",", 
+         RowBox[{"\<\"Content\"\>", 
+          "\[Rule]", "\<\"First item's subitem\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Ordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "1"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "\<\"Whitespace\"\>"}],
+          ",", 
+         RowBox[{"\<\"Content\"\>", 
+          "\[Rule]", "\<\"First item's 2nd subitem\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Ordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "2"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "\<\"Whitespace\"\>"}],
+          ",", 
+         RowBox[{"\<\"Content\"\>", 
+          "\[Rule]", "\<\"2nd item's subitem\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"Italic", ",", 
@@ -454,6 +556,7 @@ http://www.fileformat.info/info/unicode/char/2163/index.htm\"\>"}], "]"}],
       RowBox[{"\<\"Item\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
          RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
          RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
          RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"An item\"\>"}]}], 
@@ -463,6 +566,7 @@ http://www.fileformat.info/info/unicode/char/2163/index.htm\"\>"}], "]"}],
       RowBox[{"\<\"Item\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
          RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
          RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
          RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"Another item\"\>"}]}], 
@@ -472,6 +576,7 @@ http://www.fileformat.info/info/unicode/char/2163/index.htm\"\>"}], "]"}],
       RowBox[{"\<\"Item\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
          RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
          RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
          RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"Yet another item\"\>"}]}],
@@ -481,10 +586,58 @@ http://www.fileformat.info/info/unicode/char/2163/index.htm\"\>"}], "]"}],
       RowBox[{"\<\"Item\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "1"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "\<\"Tabs\"\>"}], ",", 
+         
+         RowBox[{"\<\"Content\"\>", 
+          "\[Rule]", "\<\"A nested unordered item with tabs\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
          RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
          RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
          RowBox[{"\<\"Content\"\>", 
           "\[Rule]", "\<\"And there's more...\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", 
+          "\[Rule]", "\<\"unordered list with spaces\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "1"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "\<\"Whitespace\"\>"}],
+          ",", 
+         RowBox[{"\<\"Content\"\>", 
+          "\[Rule]", "\<\"list item with space indentation\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
+    {
+     RowBox[{"MarkdownElement", "[", 
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "2"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "\<\"Whitespace\"\>"}],
+          ",", 
+         RowBox[{"\<\"Content\"\>", 
+          "\[Rule]", "\<\"another list item with space indentation\"\>"}]}], 
         "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
@@ -551,12 +704,13 @@ from.\"\>"},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"\<\"H2\"\>", ",", "\<\"LaTex\"\>"}], "]"}]},
-    {"\<\"LaTex is also supported:\"\>"},
+    {"\<\"LaTeX is also supported:\"\>"},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"\<\"Item\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
          RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
          RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
          RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"inline\"\>"}]}], 
@@ -582,6 +736,7 @@ from.\"\>"},
       RowBox[{"\<\"Item\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
          RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
          RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
          RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"presented\"\>"}]}], 
@@ -611,6 +766,7 @@ from.\"\>"},
       RowBox[{"\<\"Item\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
          RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
          RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
          RowBox[{"\<\"Content\"\>", "\[Rule]", 
@@ -631,6 +787,7 @@ want to make a link and hit \"\>", ",",
       RowBox[{"\<\"Item\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
          RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
          RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
          RowBox[{"\<\"Content\"\>", "\[Rule]", 
@@ -652,6 +809,7 @@ want to make a link and hit \"\>", ",",
       RowBox[{"\<\"Item\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
+         RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Unordered\"\>"}], ",", 
          RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
          RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
          RowBox[{"\<\"Content\"\>", "\[Rule]", 
@@ -771,8 +929,8 @@ in rendering on other platforms.\"\>"}], "}"}]}
    3.8173454763293324`*^9, 3.817346050239132*^9, 3.81734662850709*^9, 
    3.817346763411755*^9, 3.817389840621285*^9, 3.8174164489123363`*^9, 
    3.83978561192607*^9, {3.839786021507169*^9, 3.839786026115018*^9}, 
-   3.839786250526957*^9},
- CellLabel->"Out[6]=",ExpressionUUID->"1851928c-a621-40b8-b5d9-bcd902336aef"]
+   3.839786250526957*^9, 3.8452264595099916`*^9},
+ CellLabel->"Out[11]=",ExpressionUUID->"8be56051-5855-446e-af66-6707c0c615b9"]
 }, Open  ]],
 
 Cell[TextData[{
@@ -780,8 +938,7 @@ Cell[TextData[{
  Cell[BoxData[
   FormBox[
    StyleBox["ExtractMarkdownFootnote", "Input"], TraditionalForm]],
-  FormatType->TraditionalForm,ExpressionUUID->
-  "b0e0dc4e-b63e-4f55-a850-c838a32c651f"],
+  ExpressionUUID->"b0e0dc4e-b63e-4f55-a850-c838a32c651f"],
  " doesn\[CloseCurlyQuote]t work \[DownArrow]\[DownArrow]\[DownArrow]"
 }], "Text",
  CellChangeTimes->{{3.83978769828237*^9, 
@@ -1463,6 +1620,632 @@ footnote][2]"]], "ExpectedOutput" -> HoldForm[{
    3.8174159839662447`*^9, 3.817416073446569*^9, 3.8174164180390863`*^9, 
    3.839786422508462*^9},
  CellLabel->"Out[7]=",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData["MarkdownParserTestReport"], "Input",
+ CellLabel->"In[12]:=",ExpressionUUID->"d8839fb1-a010-4533-9172-beee3a24edf2"],
+
+Cell[BoxData[
+ InterpretationBox[
+  RowBox[{
+   TagBox["TestReportObject",
+    "SummaryHead"], "[", 
+   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
+    
+    TemplateBox[{
+      PaneSelectorBox[{False -> GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GraphicsBox[
+             InsetBox[
+              PaneBox[
+               DynamicBox[
+                FEPrivate`FrontEndResource["MUnitExpressions", "SuccessIcon"],
+                 ImageSizeCache -> {16., {3., 9.}}], Alignment -> Center, 
+               ImageSize -> 
+               Dynamic[{
+                 Automatic, 
+                  3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                   Magnification])}]]], AspectRatio -> 1, Axes -> False, 
+             Background -> GrayLevel[0.93], Frame -> True, FrameStyle -> 
+             Directive[
+               Thickness[Tiny], 
+               GrayLevel[0.55]], FrameTicks -> None, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}], PlotRange -> {{0, 1}, {0, 1}}], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"Title: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["Automatic", "SummaryItem"]}], "\[SpanFromLeft]"}, {
+               RowBox[{
+                 TagBox["\"Success rate: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TemplateBox[{"100", "\"%\""}, "RowDefault"], 
+                  "SummaryItem"]}], 
+               RowBox[{
+                 TagBox["\"Tests run: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["28", "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
+        GridBox[{{
+            PaneBox[
+             ButtonBox[
+              DynamicBox[
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = False), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}]], 
+            GraphicsBox[
+             InsetBox[
+              PaneBox[
+               DynamicBox[
+                FEPrivate`FrontEndResource["MUnitExpressions", "SuccessIcon"],
+                 ImageSizeCache -> {16., {3., 9.}}], Alignment -> Center, 
+               ImageSize -> 
+               Dynamic[{
+                 Automatic, 
+                  3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                   Magnification])}]]], AspectRatio -> 1, Axes -> False, 
+             Background -> GrayLevel[0.93], Frame -> True, FrameStyle -> 
+             Directive[
+               Thickness[Tiny], 
+               GrayLevel[0.55]], FrameTicks -> None, ImageSize -> 
+             Dynamic[{
+               Automatic, 
+                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                 Magnification])}], PlotRange -> {{0, 1}, {0, 1}}], 
+            GridBox[{{
+               RowBox[{
+                 TagBox["\"Title: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["Automatic", "SummaryItem"]}], "\[SpanFromLeft]"}, {
+               RowBox[{
+                 TagBox["\"Success rate: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  TemplateBox[{"100", "\"%\""}, "RowDefault"], 
+                  "SummaryItem"]}], 
+               RowBox[{
+                 TagBox["\"Tests run: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["28", "SummaryItem"]}]}, {
+               RowBox[{
+                 TagBox["\"Succeeded: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["28", "SummaryItem"]}], "\[SpanFromLeft]"}, {
+               RowBox[{
+                 TagBox["\"Failed: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["0", "SummaryItem"]}], "\[SpanFromLeft]"}, {
+               RowBox[{
+                 TagBox[
+                 "\"Failed with wrong results: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["0", "SummaryItem"]}], "\[SpanFromLeft]"}, {
+               RowBox[{
+                 TagBox[
+                 "\"Failed with messages: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["0", "SummaryItem"]}], "\[SpanFromLeft]"}, {
+               RowBox[{
+                 TagBox["\"Failed with errors: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox["0", "SummaryItem"]}], "\[SpanFromLeft]"}, {
+               RowBox[{
+                 TagBox["\"Time elapsed: \"", "SummaryItemAnnotation"], 
+                 "\[InvisibleSpace]", 
+                 TagBox[
+                  
+                  TemplateBox[{
+                   "0.003801`2.283254836092878", "\"s\"", "seconds", 
+                    "\"Seconds\""}, "Quantity"], "SummaryItem"]}], 
+               "\[SpanFromLeft]"}}, AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
+          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+          GridBoxItemSize -> {
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
+       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
+     "SummaryPanel"],
+    DynamicModuleValues:>{}], "]"}],
+  TestReportObject[
+   Association[
+   "Title" -> Automatic, "TestResults" -> Association[1 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 1, "TestID" -> "H1Test", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "# A Title"]], "ExpectedOutput" -> 
+         HoldForm[
+           MarkdownParse`MarkdownElement["H1", "A Title"]], "ActualOutput" -> 
+         HoldForm[
+           MarkdownParse`MarkdownElement["H1", "A Title"]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000226`2.504623436979395, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00026100000000006673`, "Seconds"], "MemoryUsed" -> 
+         Quantity[31392, "Bytes"]]], 2 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 2, "TestID" -> "H2Test", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "## A Subtitle"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["H2", "A Subtitle"]], "ActualOutput" -> 
+         HoldForm[
+           MarkdownParse`MarkdownElement["H2", "A Subtitle"]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000116`2.2149729870589128, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00011499999999964317`, "Seconds"], "MemoryUsed" -> 
+         Quantity[472, "Bytes"]]], 3 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 3, "TestID" -> "H3Test", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "### A Chapter"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["H3", "A Chapter"]], "ActualOutput" -> 
+         HoldForm[
+           MarkdownParse`MarkdownElement["H3", "A Chapter"]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000113`2.2035934413154137, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00011199999999966792`, "Seconds"], "MemoryUsed" -> 
+         Quantity[192, "Bytes"]]], 4 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 4, "TestID" -> "H4Test", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "#### A Section"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["H4", "A Section"]], "ActualOutput" -> 
+         HoldForm[
+           MarkdownParse`MarkdownElement["H4", "A Section"]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000107`2.1798987755172035, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010799999999999699`, "Seconds"], "MemoryUsed" -> 
+         Quantity[192, "Bytes"]]], 5 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 5, "TestID" -> "H5Test", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "##### A Subsection"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["H5", "A Subsection"]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["H5", "A Subsection"]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000109`2.1879414957726175, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010799999999999699`, "Seconds"], "MemoryUsed" -> 
+         Quantity[192, "Bytes"]]], 6 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 6, "TestID" -> "H6Test", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "###### A Subsubsection"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["H6", "A Subsubsection"]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["H6", "A Subsubsection"]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000109`2.1879414957726175, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010699999999985721`, "Seconds"], "MemoryUsed" -> 
+         Quantity[192, "Bytes"]]], 7 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 7, "TestID" -> "HNTest", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "####### A Paragraph"]], 
+         "ExpectedOutput" -> HoldForm["####### A Paragraph"], "ActualOutput" -> 
+         HoldForm["####### A Paragraph"], "ExpectedMessages" -> {}, 
+         "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000037`1.7187167218989892, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000036000000000591115`, "Seconds"], "MemoryUsed" -> 
+         Quantity[112, "Bytes"]]], 8 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 8, "TestID" -> "ItalicTest1", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "_test_"]], "ExpectedOutput" -> 
+         HoldForm[
+           MarkdownParse`MarkdownElement[Italic, "test"]], "ActualOutput" -> 
+         HoldForm[
+           MarkdownParse`MarkdownElement[Italic, "test"]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000103`2.1633522225371657, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.0001020000000000465, "Seconds"], "MemoryUsed" -> 
+         Quantity[152, "Bytes"]]], 9 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 9, "TestID" -> "ItalicTest2", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "this is a _test_"]], 
+         "ExpectedOutput" -> HoldForm[{"this is a ", 
+            MarkdownParse`MarkdownElement[Italic, "test"]}], "ActualOutput" -> 
+         HoldForm[{"this is a ", 
+            MarkdownParse`MarkdownElement[Italic, "test"]}], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.00009`2.1047575072713185, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00009199999999998099, "Seconds"], "MemoryUsed" -> 
+         Quantity[248, "Bytes"]]], 10 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 10, "TestID" -> "ItalicTest3", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "a _different kind_ of test"]], 
+         "ExpectedOutput" -> HoldForm[{"a ", 
+            MarkdownParse`MarkdownElement[Italic, "different kind"], 
+            " of test"}], "ActualOutput" -> HoldForm[{"a ", 
+            MarkdownParse`MarkdownElement[Italic, "different kind"], 
+            " of test"}], "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
+         "AbsoluteTimeUsed" -> 
+         Quantity[0.00011`2.1919076829902187, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010900000000013677`, "Seconds"], "MemoryUsed" -> 
+         Quantity[296, "Bytes"]]], 11 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 11, "TestID" -> "ItalicTest4", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, 
+            "a _slightly_ **different** _kind_ of test"]], "ExpectedOutput" -> 
+         HoldForm[{"a ", 
+            MarkdownParse`MarkdownElement[Italic, "slightly"], " ", 
+            MarkdownParse`MarkdownElement[Bold, "different"], " ", 
+            MarkdownParse`MarkdownElement[Italic, "kind"], " of test"}], 
+         "ActualOutput" -> HoldForm[{"a ", 
+            MarkdownParse`MarkdownElement[Italic, "slightly"], " ", 
+            MarkdownParse`MarkdownElement[Bold, "different"], " ", 
+            MarkdownParse`MarkdownElement[Italic, "kind"], " of test"}], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000206`2.4643822182011474, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000204000000000093, "Seconds"], "MemoryUsed" -> 
+         Quantity[640, "Bytes"]]], 12 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 12, "TestID" -> "ItalicTest5", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "a _**mixed bag**_ test"]], 
+         "ExpectedOutput" -> HoldForm[{"a ", 
+            MarkdownParse`MarkdownElement[Italic, 
+             MarkdownParse`MarkdownElement[Bold, "mixed bag"]], " test"}], 
+         "ActualOutput" -> HoldForm[{"a ", 
+            MarkdownParse`MarkdownElement[Italic, 
+             MarkdownParse`MarkdownElement[Bold, "mixed bag"]], " test"}], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000226`2.504623436979395, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00022300000000008424`, "Seconds"], "MemoryUsed" -> 
+         Quantity[560, "Bytes"]]], 13 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 13, "TestID" -> "BlockQuoteTest1",
+          "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "> a _block quote_ test"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["BlockQuote", {"a ", 
+             MarkdownParse`MarkdownElement[Italic, "block quote"], " test"}]],
+          "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["BlockQuote", {"a ", 
+             MarkdownParse`MarkdownElement[Italic, "block quote"], " test"}]],
+          "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
+         "AbsoluteTimeUsed" -> 
+         Quantity[0.000205`2.462268858887748, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000204000000000093, "Seconds"], "MemoryUsed" -> 
+         Quantity[344, "Bytes"]]], 14 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 14, "TestID" -> "TableTest1", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           Private`MarkdownTableParse[
+           "Markdown | Less | Pretty\n--- | --- | ---\n*Still* | `renders` | \
+**nicely**\n1 | 2 | 3"]], "ExpectedOutput" -> HoldForm[{
+            MarkdownParse`MarkdownElement["Table", {
+              MarkdownParse`MarkdownElement[
+              "TableHeader", {"Markdown ", " Less ", " Pretty"}], 
+              MarkdownParse`MarkdownElement[
+              "TableAlignment", {{Center}, {Center}, {Center}}], {
+               MarkdownParse`MarkdownElement["TableRow", {{
+                  MarkdownParse`MarkdownElement[Italic, "Still"], " "}, {
+                 " ", 
+                  MarkdownParse`MarkdownElement["InlineCode", "renders"], 
+                  " "}, {" ", 
+                  MarkdownParse`MarkdownElement[Bold, "nicely"]}}], 
+               MarkdownParse`MarkdownElement[
+               "TableRow", {"1 ", " 2 ", " 3"}]}}]}], "ActualOutput" -> 
+         HoldForm[{
+            MarkdownParse`MarkdownElement["Table", {
+              MarkdownParse`MarkdownElement[
+              "TableHeader", {"Markdown ", " Less ", " Pretty"}], 
+              MarkdownParse`MarkdownElement[
+              "TableAlignment", {{Center}, {Center}, {Center}}], {
+               MarkdownParse`MarkdownElement["TableRow", {{
+                  MarkdownParse`MarkdownElement[Italic, "Still"], " "}, {
+                 " ", 
+                  MarkdownParse`MarkdownElement["InlineCode", "renders"], 
+                  " "}, {" ", 
+                  MarkdownParse`MarkdownElement[Bold, "nicely"]}}], 
+               MarkdownParse`MarkdownElement[
+               "TableRow", {"1 ", " 2 ", " 3"}]}}]}], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000943`3.1250266905693223, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.0009420000000002204, "Seconds"], "MemoryUsed" -> 
+         Quantity[30176, "Bytes"]]], 15 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 15, "TestID" -> "CodeBlockTest1", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, 
+            "\n```Mathematica\nf[x]:=2;\nf[y]:=3\n```\n"]], "ExpectedOutput" -> 
+         HoldForm[{"\n", 
+            MarkdownParse`MarkdownElement["CodeBlock", 
+             Association[
+             "Language" -> "Mathematica", "Body" -> "f[x]:=2;\nf[y]:=3"]], 
+            "\n"}], "ActualOutput" -> HoldForm[{"\n", 
+            MarkdownParse`MarkdownElement["CodeBlock", 
+             Association[
+             "Language" -> "Mathematica", "Body" -> "f[x]:=2;\nf[y]:=3"]], 
+            "\n"}], "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
+         "AbsoluteTimeUsed" -> Quantity[0.000073`2.01383785795245, "Seconds"],
+          "CPUTimeUsed" -> Quantity[0.00007299999999998974, "Seconds"], 
+         "MemoryUsed" -> Quantity[704, "Bytes"]]], 16 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 16, "TestID" -> "CodeBlockTest2", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, "\n```\nf[x]:=2;\nf[y]:=3\n```\n"]], 
+         "ExpectedOutput" -> HoldForm[{"\n", 
+            MarkdownParse`MarkdownElement["CodeBlock", 
+             Association[
+             "Language" -> "None", "Body" -> "f[x]:=2;\nf[y]:=3"]], "\n"}], 
+         "ActualOutput" -> HoldForm[{"\n", 
+            MarkdownParse`MarkdownElement["CodeBlock", 
+             Association[
+             "Language" -> "None", "Body" -> "f[x]:=2;\nf[y]:=3"]], "\n"}], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000069`1.989364088569249, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00006800000000017903, "Seconds"], "MemoryUsed" -> 
+         Quantity[592, "Bytes"]]], 17 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 17, "TestID" -> "CodeBlockTest3", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, 
+            "\n    A generic code block\n    With some text\n"]], 
+         "ExpectedOutput" -> HoldForm[{"\n", 
+            MarkdownParse`MarkdownElement["CodeBlock", 
+             Association[
+             "Language" -> "None", "Body" -> 
+              "A generic code block\n    With some text\n"]]}], 
+         "ActualOutput" -> HoldForm[{"\n", 
+            MarkdownParse`MarkdownElement["CodeBlock", 
+             Association[
+             "Language" -> "None", "Body" -> 
+              "A generic code block\n    With some text\n"]]}], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.00005`1.849485002168013, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004900000000018778, "Seconds"], "MemoryUsed" -> 
+         Quantity[576, "Bytes"]]], 18 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 18, "TestID" -> "InlineCodeTest1",
+          "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "`inline code`"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["InlineCode", "inline code"]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["InlineCode", "inline code"]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000059`1.9213670094741384, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000058999999999809205`, "Seconds"], "MemoryUsed" -> 
+         Quantity[160, "Bytes"]]], 19 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 19, "TestID" -> "InlineCodeTest2",
+          "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, 
+            "insert inline `code block` formatting anywhere"]], 
+         "ExpectedOutput" -> HoldForm[{"insert inline ", 
+            MarkdownParse`MarkdownElement["InlineCode", "code block"], 
+            " formatting anywhere"}], "ActualOutput" -> 
+         HoldForm[{"insert inline ", 
+            MarkdownParse`MarkdownElement["InlineCode", "code block"], 
+            " formatting anywhere"}], "ExpectedMessages" -> {}, 
+         "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000083`2.069593090208068, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00008300000000005525, "Seconds"], "MemoryUsed" -> 
+         Quantity[312, "Bytes"]]], 20 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 20, "TestID" -> "InlineCodeTest3",
+          "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, 
+            "### A Chapter heading with `inline code` inserted"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["H3", {"A Chapter heading with ", 
+             MarkdownParse`MarkdownElement["InlineCode", "inline code"], 
+             " inserted"}]], "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["H3", {"A Chapter heading with ", 
+             MarkdownParse`MarkdownElement["InlineCode", "inline code"], 
+             " inserted"}]], "ExpectedMessages" -> {}, "ActualMessages" -> {},
+          "AbsoluteTimeUsed" -> 
+         Quantity[0.000239`2.5289128987801313, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.0002369999999998207, "Seconds"], "MemoryUsed" -> 
+         Quantity[456, "Bytes"]]], 21 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 21, "TestID" -> 
+         "InlineLaTeXTest1", "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "\(a^2 + b^2 = c^2\)"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["LaTeX", 
+            Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["LaTeX", 
+            Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000043`1.7839834534115804, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004300000000023729, "Seconds"], "MemoryUsed" -> 
+         Quantity[520, "Bytes"]]], 22 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 22, "TestID" -> 
+         "InlineLaTeXTest2", "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "$ a^2 + b^2 = c^2 $"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["LaTeX", 
+            Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["LaTeX", 
+            Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000041`1.7632988545517294, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00003900000000012227, "Seconds"], "MemoryUsed" -> 
+         Quantity[464, "Bytes"]]], 23 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 23, "TestID" -> 
+         "DisplayLaTeXTest1", "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "\\[ a^n + b^n = c^n \\]"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["LaTeX", 
+            Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["LaTeX", 
+            Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.00004`1.752574989159956, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00003900000000012227, "Seconds"], "MemoryUsed" -> 
+         Quantity[456, "Bytes"]]], 24 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 24, "TestID" -> 
+         "DisplayLaTeXTest2", "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "$$ a^2 + b^2 = c^2 $$"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["LaTeX", 
+            Association["Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]],
+          "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["LaTeX", 
+            Association["Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]],
+          "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
+         "AbsoluteTimeUsed" -> 
+         Quantity[0.000041`1.763298854551729, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00003900000000012227, "Seconds"], "MemoryUsed" -> 
+         Quantity[464, "Bytes"]]], 25 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 25, "TestID" -> "LinkTest1", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, "[click here](www.google.com)"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement[Hyperlink, 
+            Association[
+            "Label" -> "click here", "Link" -> "www.google.com"]]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement[Hyperlink, 
+            Association[
+            "Label" -> "click here", "Link" -> "www.google.com"]]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000095`2.128238603120842, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00009400000000026054, "Seconds"], "MemoryUsed" -> 
+         Quantity[568, "Bytes"]]], 26 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 26, "TestID" -> "LinkTest2", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "<www.google.com>"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement[Hyperlink, 
+            Association["Link" -> "www.google.com"]]], "ActualOutput" -> 
+         HoldForm[
+           MarkdownParse`MarkdownElement[Hyperlink, 
+            Association["Link" -> "www.google.com"]]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000041`1.763298854551729, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004099999999951365, "Seconds"], "MemoryUsed" -> 
+         Quantity[440, "Bytes"]]], 27 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 27, "TestID" -> "ImageLinkTest1", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, 
+            "![Streetview of Palm Trees by Brandon \
+Erlinger-Ford](https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
+ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
+format&fit=crop&w=564&q=80)"]], "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement[Hyperlink, 
+            Association[
+            "AltText" -> "Streetview of Palm Trees by Brandon Erlinger-Ford", 
+             "Link" -> 
+             "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
+ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
+format&fit=crop&w=564&q=80"]]], "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement[Hyperlink, 
+            Association[
+            "AltText" -> "Streetview of Palm Trees by Brandon Erlinger-Ford", 
+             "Link" -> 
+             "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
+ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
+format&fit=crop&w=564&q=80"]]], "ExpectedMessages" -> {}, 
+         "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000061`1.935844832842761, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00005999999999994898, "Seconds"], "MemoryUsed" -> 
+         Quantity[752, "Bytes"]]], 28 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 28, "TestID" -> "FoonoteTest1", 
+         "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, 
+            "[The first footnote][1] was there and here's [the second \
+footnote][2]"]], "ExpectedOutput" -> HoldForm[{
+            MarkdownParse`MarkdownElement[Hyperlink, "The first footnote", 
+             MarkdownParse`MarkdownElement["FootnoteReference", {1}]], 
+            " was there and here's", 
+            MarkdownParse`MarkdownElement[Hyperlink, "the second footnote", 
+             MarkdownParse`MarkdownElement["FootnoteReference", {2}]]}], 
+         "ActualOutput" -> HoldForm[{
+            MarkdownParse`MarkdownElement[Hyperlink, "The first footnote", 
+             MarkdownParse`MarkdownElement["FootnoteReference", {1}]], 
+            " was there and here's", 
+            MarkdownParse`MarkdownElement[Hyperlink, "the second footnote", 
+             MarkdownParse`MarkdownElement["FootnoteReference", {2}]]}], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000166`2.370623085872049, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00016499999999997073`, "Seconds"], "MemoryUsed" -> 
+         Quantity[608, "Bytes"]]]], 
+    "TestsSucceededIndices" -> {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28}, 
+    "TestsFailedIndices" -> {}, "TestsFailedWrongResultsIndices" -> {}, 
+    "TestsFailedWithMessagesIndices" -> {}, 
+    "TestsFailedWithErrorsIndices" -> {}, "TimeElapsed" -> 
+    Quantity[0.003801`2.283254836092878, "Seconds"], "TestsSucceededCount" -> 
+    28, "TestsFailedCount" -> 0, "TestsFailedWrongResultsCount" -> 0, 
+    "TestsFailedWithMessagesCount" -> 0, "TestsFailedWithErrorsCount" -> 0, 
+    "Aborted" -> False]],
+  Editable->False,
+  SelectWithContents->True,
+  Selectable->False]], "Output",
+ CellChangeTimes->{3.845226719611676*^9},
+ CellLabel->"Out[12]=",ExpressionUUID->"03a2d32d-c89c-4f8a-83d7-c9ecf1566c64"]
 }, Open  ]]
 }, Open  ]],
 
@@ -4431,7 +5214,7 @@ on other platforms."], "Tooltip"]& ]}}],
 }, Open  ]]
 }, Open  ]]
 },
-WindowSize->{1440, 847},
+WindowSize->{1696, 1387},
 WindowMargins->{{0, Automatic}, {Automatic, 0}},
 TaggingRules->{
  "WelcomeScreenSettings" -> {"FEStarting" -> False}, "TryRealOnly" -> False},
@@ -4455,48 +5238,52 @@ Cell[580, 22, 261, 4, 98, "Title",ExpressionUUID->"b7946855-acef-475d-bca3-4f6aa
 Cell[844, 28, 336, 5, 62, "Abstract",ExpressionUUID->"41f6fde2-3312-478f-b2c8-ff97b1cd3e62"],
 Cell[1183, 35, 249, 4, 35, "Text",ExpressionUUID->"ae62ea4f-43d4-4edf-903f-316f87708814"],
 Cell[1435, 41, 160, 3, 38, "CodeText",ExpressionUUID->"fea4a3a1-ea63-4863-a1c5-7652c6364503"],
-Cell[1598, 46, 177, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
-Cell[1778, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
-Cell[1968, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
-Cell[2236, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
-Cell[2518, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
-Cell[2735, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
-Cell[2930, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
+Cell[1598, 46, 176, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+Cell[1777, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
+Cell[1967, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
+Cell[2235, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
+Cell[2517, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
+Cell[2734, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
+Cell[2929, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
 Cell[CellGroupData[{
-Cell[3348, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
-Cell[3562, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
+Cell[3347, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
+Cell[3561, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
 Cell[CellGroupData[{
-Cell[3774, 103, 536, 12, 30, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
-Cell[4313, 117, 5901, 143, 403, "Output",ExpressionUUID->"9d30d1e1-3b38-4327-b7fa-5f15a0c5141e"]
+Cell[3773, 103, 536, 12, 30, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
+Cell[4312, 117, 6329, 152, 403, "Output",ExpressionUUID->"3b4e9d5f-2ca3-4524-b7a9-f0828e41a3fe"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10263, 266, 265, 4, 67, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
-Cell[10531, 272, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
+Cell[10690, 275, 265, 4, 67, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
+Cell[10958, 281, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
 Cell[CellGroupData[{
-Cell[11207, 289, 249, 4, 30, "Input",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
-Cell[11459, 295, 3837, 50, 2429, "Output",ExpressionUUID->"1c788981-27b2-4fe6-a8a9-38507ecb363b"]
+Cell[11634, 298, 295, 5, 30, "Input",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
+Cell[11932, 305, 4222, 56, 2639, "Output",ExpressionUUID->"35f09d72-a78d-43d5-8a17-d90e59057af6"]
+}, Closed]],
+Cell[16169, 364, 511, 9, 26, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
+Cell[CellGroupData[{
+Cell[16705, 377, 265, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
+Cell[16973, 384, 24025, 548, 1547, "Output",ExpressionUUID->"8be56051-5855-446e-af66-6707c0c615b9"]
 }, Open  ]],
-Cell[15311, 348, 511, 9, 30, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
-Cell[CellGroupData[{
-Cell[15847, 361, 264, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
-Cell[16114, 368, 17426, 406, 1417, "Output",ExpressionUUID->"1851928c-a621-40b8-b5d9-bcd902336aef"]
-}, Open  ]],
-Cell[33555, 777, 427, 11, 35, "Text",ExpressionUUID->"fd11d7bb-32c7-4cc0-b0ef-780fc0134e6d"],
-Cell[33985, 790, 1151, 24, 73, "Input",ExpressionUUID->"b263aba7-97b0-4acf-882c-d77f77a17c66"]
+Cell[41013, 935, 396, 10, 35, "Text",ExpressionUUID->"fd11d7bb-32c7-4cc0-b0ef-780fc0134e6d"],
+Cell[41412, 947, 1151, 24, 73, "Input",ExpressionUUID->"b263aba7-97b0-4acf-882c-d77f77a17c66"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[35173, 819, 157, 3, 67, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
+Cell[42600, 976, 157, 3, 67, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
 Cell[CellGroupData[{
-Cell[35355, 826, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
-Cell[35486, 829, 35105, 635, 63, "Output",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
+Cell[42782, 983, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
+Cell[42913, 986, 35105, 635, 63, "Output",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[78055, 1626, 129, 1, 30, "Input",ExpressionUUID->"d8839fb1-a010-4533-9172-beee3a24edf2"],
+Cell[78187, 1629, 33983, 618, 63, "Output",ExpressionUUID->"03a2d32d-c89c-4f8a-83d7-c9ecf1566c64"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[70640, 1470, 213, 4, 67, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
+Cell[112219, 2253, 213, 4, 67, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
 Cell[CellGroupData[{
-Cell[70878, 1478, 504, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
-Cell[71385, 1489, 132096, 2939, 301, "Output",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
+Cell[112457, 2261, 504, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
+Cell[112964, 2272, 132096, 2939, 301, "Output",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]]

--- a/Parser/MarkdownParserDemo.nb
+++ b/Parser/MarkdownParserDemo.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    245180,       5241]
-NotebookOptionsPosition[    241439,       5172]
-NotebookOutlinePosition[    241926,       5190]
-CellTagsIndexPosition[    241883,       5187]
+NotebookDataLength[    209069,       4569]
+NotebookOptionsPosition[    205750,       4506]
+NotebookOutlinePosition[    206237,       4524]
+CellTagsIndexPosition[    206194,       4521]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -46,7 +46,7 @@ Cell["Quit the kernel", "CodeText",
 
 Cell[BoxData["Quit"], "Input",
  CellChangeTimes->{{3.817239754310732*^9, 3.8172397548456573`*^9}},
- CellLabel->"In[13]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+ CellLabel->"In[7]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
 
 Cell["Install the packages again from the Menu:", "Text",
  CellChangeTimes->{{3.8174165987397127`*^9, 
@@ -113,7 +113,7 @@ Cell[BoxData[
      RowBox[{"Frame", "\[Rule]", "All"}]}], "]"}], "&"}]}]], "Input",
  CellChangeTimes->{{3.8173380564205627`*^9, 3.817338059952167*^9}, {
   3.8173382937088327`*^9, 3.8173383261851873`*^9}},
- CellLabel->"In[3]:=",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
+ CellLabel->"In[9]:=",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
 
 Cell[BoxData[
  TagBox[GridBox[{
@@ -266,8 +266,9 @@ Cell[BoxData[
    3.817389589946957*^9, 3.817423982038066*^9, 3.8397853572118587`*^9, {
    3.839785419382757*^9, 3.8397854364402733`*^9}, {3.839785527027009*^9, 
    3.839785540844495*^9}, 3.839786014047813*^9, 3.8397862448168993`*^9, 
-   3.845226378341282*^9, 3.84522716739851*^9},
- CellLabel->"Out[3]=",ExpressionUUID->"9e8c8536-6d50-4b44-b5a1-3a64d5972403"]
+   3.845226378341282*^9, 3.84522716739851*^9, 3.845228657170726*^9, 
+   3.8452301157611837`*^9},
+ CellLabel->"Out[9]=",ExpressionUUID->"572dcb8e-5090-4ce3-81ef-7a6465304c32"]
 }, Open  ]]
 }, Open  ]],
 
@@ -292,7 +293,7 @@ Cell[BoxData[
    3.817157937214015*^9}, {3.8172366531060762`*^9, 3.8172366534588127`*^9}, 
    3.817330653594535*^9, {3.81738967309939*^9, 3.817389685568739*^9}, {
    3.8173897935513268`*^9, 3.817389831975668*^9}},
- CellLabel->"In[4]:=",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
+ CellLabel->"In[3]:=",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
 
 Cell[BoxData[
  RowBox[{
@@ -300,7 +301,7 @@ Cell[BoxData[
    RowBox[{"filePath", ",", "\"\<Text\>\""}], "]"}], ";"}]], "Input",
  CellChangeTimes->{{3.839786671641347*^9, 3.8397867032127323`*^9}, {
    3.845226422574849*^9, 3.845226424824779*^9}, 3.845227179074463*^9},
- CellLabel->"In[6]:=",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
+ CellLabel->"In[4]:=",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
 
 Cell[CellGroupData[{
 
@@ -313,20 +314,16 @@ Cell[BoxData[
    3.8171704049186897`*^9}, 3.8172358431384687`*^9, {3.817240946833456*^9, 
    3.81724094888334*^9}, 3.8172413585269203`*^9, {3.81734384974724*^9, 
    3.817343850827291*^9}},
- CellLabel->"In[7]:=",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
+ CellLabel->"In[5]:=",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
 
-Cell[BoxData[
- RowBox[{
-  TagBox["\<\"FootFile\"\>",
-   "EchoLabel"], 
-  "  ", "\<\"[1]: http://daringfireball.net/projects/markdown/\\n[2]: \
+Cell[BoxData["\<\"[1]: http://daringfireball.net/projects/markdown/\\n[2]: \
 http://www.fileformat.info/info/unicode/char/2163/index.htm\\n[3]: \
 http://www.markitdown.net/\\n[4]: \
 http://daringfireball.net/projects/markdown/basics\\n[5]: \
-http://daringfireball.net/projects/markdown/syntax\"\>"}]], "Echo",
+http://daringfireball.net/projects/markdown/syntax\"\>"], "Echo",
  CellChangeTimes->{
-  3.845227180636941*^9},ExpressionUUID->"605c8bc1-821f-457c-a598-\
-e40741ffbb34"]
+  3.845230439546041*^9},ExpressionUUID->"5e65cb7f-7e05-4941-9c71-\
+bf937faeafb1"]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -336,7 +333,7 @@ Cell[BoxData[
   RowBox[{"mdp", ",", 
    RowBox[{"Frame", "\[Rule]", "All"}]}], "]"}]], "Input",
  CellChangeTimes->{{3.817333311218748*^9, 3.817333316916204*^9}},
- CellLabel->"In[8]:=",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
+ CellLabel->"In[6]:=",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
 
 Cell[BoxData[
  TagBox[GridBox[{
@@ -729,11 +726,10 @@ from.\"\>"},
           RowBox[{"{", 
            RowBox[{"\<\"A named link to\"\>", ",", 
             RowBox[{"MarkdownElement", "[", 
-             RowBox[{"Hyperlink", ",", "\<\"MarkItDown\"\>", ",", 
-              RowBox[{"First", "[", 
-               RowBox[{"Private`ExtractMarkdownFootnoteURL", "[", 
-                RowBox[{"3", ",", "Private`footFile"}], "]"}], "]"}]}], "]"}],
-             ",", "\<\". The easiest way to do these is to select what you \
+             RowBox[{
+             "Hyperlink", ",", "\<\"MarkItDown\"\>", 
+              ",", "\<\" http://www.markitdown.net/\"\>"}], "]"}], 
+            ",", "\<\". The easiest way to do these is to select what you \
 want to make a link and hit \"\>", ",", 
             RowBox[{"MarkdownElement", "[", 
              RowBox[{"\<\"InlineCode\"\>", ",", "\<\"Ctrl+L\"\>"}], "]"}], 
@@ -885,47 +881,11 @@ in rendering on other platforms.\"\>"}], "}"}]}
    3.8173454763293324`*^9, 3.817346050239132*^9, 3.81734662850709*^9, 
    3.817346763411755*^9, 3.817389840621285*^9, 3.8174164489123363`*^9, 
    3.83978561192607*^9, {3.839786021507169*^9, 3.839786026115018*^9}, 
-   3.839786250526957*^9, 3.8452264595099916`*^9, 3.845227189799056*^9},
- CellLabel->"Out[8]=",ExpressionUUID->"f3c27957-ee9c-4018-9df1-23406b00f1a6"]
-}, Open  ]],
-
-Cell[TextData[{
- "Not sure why ",
- Cell[BoxData[
-  FormBox[
-   StyleBox["ExtractMarkdownFootnote", "Input"], TraditionalForm]],
-  ExpressionUUID->"b0e0dc4e-b63e-4f55-a850-c838a32c651f"],
- " doesn\[CloseCurlyQuote]t work \[DownArrow]\[DownArrow]\[DownArrow]"
-}], "Text",
- CellChangeTimes->{{3.83978769828237*^9, 
-  3.8397877089314823`*^9}},ExpressionUUID->"fd11d7bb-32c7-4cc0-b0ef-\
-780fc0134e6d"],
-
-Cell[BoxData[
- RowBox[{"MarkdownElement", "[", 
-  RowBox[{"\"\<Item\>\"", ",", 
-   RowBox[{"\[LeftAssociation]", 
-    RowBox[{
-     RowBox[{"\"\<IndentationLevel\>\"", "\[Rule]", "0"}], ",", 
-     RowBox[{"\"\<IndentationType\>\"", "\[Rule]", "None"}], ",", 
-     RowBox[{"\"\<Content\>\"", "\[Rule]", 
-      RowBox[{"{", 
-       RowBox[{"\"\<A named link to\>\"", ",", 
-        RowBox[{"MarkdownElement", "[", 
-         RowBox[{"Hyperlink", ",", "\"\<MarkItDown\>\"", ",", 
-          StyleBox[
-           RowBox[{"First", "[", 
-            RowBox[{"Private`ExtractMarkdownFootnoteURL", "[", 
-             RowBox[{"3", ",", "Private`footFile"}], "]"}], "]"}],
-           Background->RGBColor[1, 0.85, 0.85]]}], "]"}], ",", 
-        "\"\<. The easiest way to do these is to select what you want to make \
-a link and hit \>\"", ",", 
-        RowBox[{"MarkdownElement", "[", 
-         RowBox[{"\"\<InlineCode\>\"", ",", "\"\<Ctrl+L\>\""}], "]"}], ",", 
-        "\"\<.\>\""}], "}"}]}]}], "\[RightAssociation]"}]}], "]"}]], "Input",
- CellChangeTimes->{3.839787558385516*^9, 
-  3.839787630053808*^9},ExpressionUUID->"b263aba7-97b0-4acf-882c-\
-d77f77a17c66"]
+   3.839786250526957*^9, 3.8452264595099916`*^9, 3.845227189799056*^9, 
+   3.845228682065586*^9, 3.845230086802711*^9, 3.845230183075725*^9, 
+   3.8452303148139267`*^9, 3.845230353618988*^9, 3.845230440854608*^9},
+ CellLabel->"Out[6]=",ExpressionUUID->"b5797c9a-9cde-4877-9304-0457ea6b3c8e"]
+}, Open  ]]
 }, Open  ]],
 
 Cell[CellGroupData[{
@@ -1576,634 +1536,8 @@ footnote][2]"]], "ExpectedOutput" -> HoldForm[{
    3.8174159839662447`*^9, 3.817416073446569*^9, 3.8174164180390863`*^9, 
    3.839786422508462*^9},
  CellLabel->"Out[7]=",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
-}, Open  ]],
-
-Cell[CellGroupData[{
-
-Cell[BoxData["MarkdownParserTestReport"], "Input",
- CellLabel->"In[12]:=",ExpressionUUID->"d8839fb1-a010-4533-9172-beee3a24edf2"],
-
-Cell[BoxData[
- InterpretationBox[
-  RowBox[{
-   TagBox["TestReportObject",
-    "SummaryHead"], "[", 
-   DynamicModuleBox[{Typeset`open$$ = False, Typeset`embedState$$ = "Ready"}, 
-    
-    TemplateBox[{
-      PaneSelectorBox[{False -> GridBox[{{
-            PaneBox[
-             ButtonBox[
-              DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
-               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
-              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
-              Evaluator -> Automatic, Method -> "Preemptive"], 
-             Alignment -> {Center, Center}, ImageSize -> 
-             Dynamic[{
-               Automatic, 
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}]], 
-            GraphicsBox[
-             InsetBox[
-              PaneBox[
-               DynamicBox[
-                FEPrivate`FrontEndResource["MUnitExpressions", "SuccessIcon"],
-                 ImageSizeCache -> {16., {3., 9.}}], Alignment -> Center, 
-               ImageSize -> 
-               Dynamic[{
-                 Automatic, 
-                  3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                   Magnification])}]]], AspectRatio -> 1, Axes -> False, 
-             Background -> GrayLevel[0.93], Frame -> True, FrameStyle -> 
-             Directive[
-               Thickness[Tiny], 
-               GrayLevel[0.55]], FrameTicks -> None, ImageSize -> 
-             Dynamic[{
-               Automatic, 
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}], PlotRange -> {{0, 1}, {0, 1}}], 
-            GridBox[{{
-               RowBox[{
-                 TagBox["\"Title: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["Automatic", "SummaryItem"]}], "\[SpanFromLeft]"}, {
-               RowBox[{
-                 TagBox["\"Success rate: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  TemplateBox[{"100", "\"%\""}, "RowDefault"], 
-                  "SummaryItem"]}], 
-               RowBox[{
-                 TagBox["\"Tests run: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["28", "SummaryItem"]}]}}, AutoDelete -> False, 
-             BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-             GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {
-              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
-          False, BaselinePosition -> {1, 1}, 
-          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
-        GridBox[{{
-            PaneBox[
-             ButtonBox[
-              DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"], 
-               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
-              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = False), 
-              Evaluator -> Automatic, Method -> "Preemptive"], 
-             Alignment -> {Center, Center}, ImageSize -> 
-             Dynamic[{
-               Automatic, 
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}]], 
-            GraphicsBox[
-             InsetBox[
-              PaneBox[
-               DynamicBox[
-                FEPrivate`FrontEndResource["MUnitExpressions", "SuccessIcon"],
-                 ImageSizeCache -> {16., {3., 9.}}], Alignment -> Center, 
-               ImageSize -> 
-               Dynamic[{
-                 Automatic, 
-                  3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                   Magnification])}]]], AspectRatio -> 1, Axes -> False, 
-             Background -> GrayLevel[0.93], Frame -> True, FrameStyle -> 
-             Directive[
-               Thickness[Tiny], 
-               GrayLevel[0.55]], FrameTicks -> None, ImageSize -> 
-             Dynamic[{
-               Automatic, 
-                3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}], PlotRange -> {{0, 1}, {0, 1}}], 
-            GridBox[{{
-               RowBox[{
-                 TagBox["\"Title: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["Automatic", "SummaryItem"]}], "\[SpanFromLeft]"}, {
-               RowBox[{
-                 TagBox["\"Success rate: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  TemplateBox[{"100", "\"%\""}, "RowDefault"], 
-                  "SummaryItem"]}], 
-               RowBox[{
-                 TagBox["\"Tests run: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["28", "SummaryItem"]}]}, {
-               RowBox[{
-                 TagBox["\"Succeeded: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["28", "SummaryItem"]}], "\[SpanFromLeft]"}, {
-               RowBox[{
-                 TagBox["\"Failed: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["0", "SummaryItem"]}], "\[SpanFromLeft]"}, {
-               RowBox[{
-                 TagBox[
-                 "\"Failed with wrong results: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["0", "SummaryItem"]}], "\[SpanFromLeft]"}, {
-               RowBox[{
-                 TagBox[
-                 "\"Failed with messages: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["0", "SummaryItem"]}], "\[SpanFromLeft]"}, {
-               RowBox[{
-                 TagBox["\"Failed with errors: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox["0", "SummaryItem"]}], "\[SpanFromLeft]"}, {
-               RowBox[{
-                 TagBox["\"Time elapsed: \"", "SummaryItemAnnotation"], 
-                 "\[InvisibleSpace]", 
-                 TagBox[
-                  
-                  TemplateBox[{
-                   "0.003801`2.283254836092878", "\"s\"", "seconds", 
-                    "\"Seconds\""}, "Quantity"], "SummaryItem"]}], 
-               "\[SpanFromLeft]"}}, AutoDelete -> False, 
-             BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
-             GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {
-              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
-          False, BaselinePosition -> {1, 1}, 
-          GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
-       Dynamic[Typeset`open$$], ImageSize -> Automatic]},
-     "SummaryPanel"],
-    DynamicModuleValues:>{}], "]"}],
-  TestReportObject[
-   Association[
-   "Title" -> Automatic, "TestResults" -> Association[1 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 1, "TestID" -> "H1Test", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "# A Title"]], "ExpectedOutput" -> 
-         HoldForm[
-           MarkdownParse`MarkdownElement["H1", "A Title"]], "ActualOutput" -> 
-         HoldForm[
-           MarkdownParse`MarkdownElement["H1", "A Title"]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000226`2.504623436979395, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00026100000000006673`, "Seconds"], "MemoryUsed" -> 
-         Quantity[31392, "Bytes"]]], 2 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 2, "TestID" -> "H2Test", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "## A Subtitle"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["H2", "A Subtitle"]], "ActualOutput" -> 
-         HoldForm[
-           MarkdownParse`MarkdownElement["H2", "A Subtitle"]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000116`2.2149729870589128, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00011499999999964317`, "Seconds"], "MemoryUsed" -> 
-         Quantity[472, "Bytes"]]], 3 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 3, "TestID" -> "H3Test", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "### A Chapter"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["H3", "A Chapter"]], "ActualOutput" -> 
-         HoldForm[
-           MarkdownParse`MarkdownElement["H3", "A Chapter"]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000113`2.2035934413154137, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00011199999999966792`, "Seconds"], "MemoryUsed" -> 
-         Quantity[192, "Bytes"]]], 4 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 4, "TestID" -> "H4Test", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "#### A Section"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["H4", "A Section"]], "ActualOutput" -> 
-         HoldForm[
-           MarkdownParse`MarkdownElement["H4", "A Section"]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000107`2.1798987755172035, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010799999999999699`, "Seconds"], "MemoryUsed" -> 
-         Quantity[192, "Bytes"]]], 5 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 5, "TestID" -> "H5Test", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "##### A Subsection"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["H5", "A Subsection"]], 
-         "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["H5", "A Subsection"]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000109`2.1879414957726175, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010799999999999699`, "Seconds"], "MemoryUsed" -> 
-         Quantity[192, "Bytes"]]], 6 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 6, "TestID" -> "H6Test", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "###### A Subsubsection"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["H6", "A Subsubsection"]], 
-         "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["H6", "A Subsubsection"]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000109`2.1879414957726175, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010699999999985721`, "Seconds"], "MemoryUsed" -> 
-         Quantity[192, "Bytes"]]], 7 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 7, "TestID" -> "HNTest", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "####### A Paragraph"]], 
-         "ExpectedOutput" -> HoldForm["####### A Paragraph"], "ActualOutput" -> 
-         HoldForm["####### A Paragraph"], "ExpectedMessages" -> {}, 
-         "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000037`1.7187167218989892, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.000036000000000591115`, "Seconds"], "MemoryUsed" -> 
-         Quantity[112, "Bytes"]]], 8 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 8, "TestID" -> "ItalicTest1", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "_test_"]], "ExpectedOutput" -> 
-         HoldForm[
-           MarkdownParse`MarkdownElement[Italic, "test"]], "ActualOutput" -> 
-         HoldForm[
-           MarkdownParse`MarkdownElement[Italic, "test"]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000103`2.1633522225371657, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0001020000000000465, "Seconds"], "MemoryUsed" -> 
-         Quantity[152, "Bytes"]]], 9 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 9, "TestID" -> "ItalicTest2", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "this is a _test_"]], 
-         "ExpectedOutput" -> HoldForm[{"this is a ", 
-            MarkdownParse`MarkdownElement[Italic, "test"]}], "ActualOutput" -> 
-         HoldForm[{"this is a ", 
-            MarkdownParse`MarkdownElement[Italic, "test"]}], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.00009`2.1047575072713185, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00009199999999998099, "Seconds"], "MemoryUsed" -> 
-         Quantity[248, "Bytes"]]], 10 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 10, "TestID" -> "ItalicTest3", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "a _different kind_ of test"]], 
-         "ExpectedOutput" -> HoldForm[{"a ", 
-            MarkdownParse`MarkdownElement[Italic, "different kind"], 
-            " of test"}], "ActualOutput" -> HoldForm[{"a ", 
-            MarkdownParse`MarkdownElement[Italic, "different kind"], 
-            " of test"}], "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 
-         Quantity[0.00011`2.1919076829902187, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010900000000013677`, "Seconds"], "MemoryUsed" -> 
-         Quantity[296, "Bytes"]]], 11 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 11, "TestID" -> "ItalicTest4", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[
-           Private`MarkdownParser, 
-            "a _slightly_ **different** _kind_ of test"]], "ExpectedOutput" -> 
-         HoldForm[{"a ", 
-            MarkdownParse`MarkdownElement[Italic, "slightly"], " ", 
-            MarkdownParse`MarkdownElement[Bold, "different"], " ", 
-            MarkdownParse`MarkdownElement[Italic, "kind"], " of test"}], 
-         "ActualOutput" -> HoldForm[{"a ", 
-            MarkdownParse`MarkdownElement[Italic, "slightly"], " ", 
-            MarkdownParse`MarkdownElement[Bold, "different"], " ", 
-            MarkdownParse`MarkdownElement[Italic, "kind"], " of test"}], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000206`2.4643822182011474, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.000204000000000093, "Seconds"], "MemoryUsed" -> 
-         Quantity[640, "Bytes"]]], 12 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 12, "TestID" -> "ItalicTest5", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "a _**mixed bag**_ test"]], 
-         "ExpectedOutput" -> HoldForm[{"a ", 
-            MarkdownParse`MarkdownElement[Italic, 
-             MarkdownParse`MarkdownElement[Bold, "mixed bag"]], " test"}], 
-         "ActualOutput" -> HoldForm[{"a ", 
-            MarkdownParse`MarkdownElement[Italic, 
-             MarkdownParse`MarkdownElement[Bold, "mixed bag"]], " test"}], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000226`2.504623436979395, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00022300000000008424`, "Seconds"], "MemoryUsed" -> 
-         Quantity[560, "Bytes"]]], 13 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 13, "TestID" -> "BlockQuoteTest1",
-          "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "> a _block quote_ test"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["BlockQuote", {"a ", 
-             MarkdownParse`MarkdownElement[Italic, "block quote"], " test"}]],
-          "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["BlockQuote", {"a ", 
-             MarkdownParse`MarkdownElement[Italic, "block quote"], " test"}]],
-          "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 
-         Quantity[0.000205`2.462268858887748, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.000204000000000093, "Seconds"], "MemoryUsed" -> 
-         Quantity[344, "Bytes"]]], 14 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 14, "TestID" -> "TableTest1", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           Private`MarkdownTableParse[
-           "Markdown | Less | Pretty\n--- | --- | ---\n*Still* | `renders` | \
-**nicely**\n1 | 2 | 3"]], "ExpectedOutput" -> HoldForm[{
-            MarkdownParse`MarkdownElement["Table", {
-              MarkdownParse`MarkdownElement[
-              "TableHeader", {"Markdown ", " Less ", " Pretty"}], 
-              MarkdownParse`MarkdownElement[
-              "TableAlignment", {{Center}, {Center}, {Center}}], {
-               MarkdownParse`MarkdownElement["TableRow", {{
-                  MarkdownParse`MarkdownElement[Italic, "Still"], " "}, {
-                 " ", 
-                  MarkdownParse`MarkdownElement["InlineCode", "renders"], 
-                  " "}, {" ", 
-                  MarkdownParse`MarkdownElement[Bold, "nicely"]}}], 
-               MarkdownParse`MarkdownElement[
-               "TableRow", {"1 ", " 2 ", " 3"}]}}]}], "ActualOutput" -> 
-         HoldForm[{
-            MarkdownParse`MarkdownElement["Table", {
-              MarkdownParse`MarkdownElement[
-              "TableHeader", {"Markdown ", " Less ", " Pretty"}], 
-              MarkdownParse`MarkdownElement[
-              "TableAlignment", {{Center}, {Center}, {Center}}], {
-               MarkdownParse`MarkdownElement["TableRow", {{
-                  MarkdownParse`MarkdownElement[Italic, "Still"], " "}, {
-                 " ", 
-                  MarkdownParse`MarkdownElement["InlineCode", "renders"], 
-                  " "}, {" ", 
-                  MarkdownParse`MarkdownElement[Bold, "nicely"]}}], 
-               MarkdownParse`MarkdownElement[
-               "TableRow", {"1 ", " 2 ", " 3"}]}}]}], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000943`3.1250266905693223, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0009420000000002204, "Seconds"], "MemoryUsed" -> 
-         Quantity[30176, "Bytes"]]], 15 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 15, "TestID" -> "CodeBlockTest1", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[
-           Private`MarkdownParser, 
-            "\n```Mathematica\nf[x]:=2;\nf[y]:=3\n```\n"]], "ExpectedOutput" -> 
-         HoldForm[{"\n", 
-            MarkdownParse`MarkdownElement["CodeBlock", 
-             Association[
-             "Language" -> "Mathematica", "Body" -> "f[x]:=2;\nf[y]:=3"]], 
-            "\n"}], "ActualOutput" -> HoldForm[{"\n", 
-            MarkdownParse`MarkdownElement["CodeBlock", 
-             Association[
-             "Language" -> "Mathematica", "Body" -> "f[x]:=2;\nf[y]:=3"]], 
-            "\n"}], "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> Quantity[0.000073`2.01383785795245, "Seconds"],
-          "CPUTimeUsed" -> Quantity[0.00007299999999998974, "Seconds"], 
-         "MemoryUsed" -> Quantity[704, "Bytes"]]], 16 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 16, "TestID" -> "CodeBlockTest2", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[
-           Private`MarkdownParser, "\n```\nf[x]:=2;\nf[y]:=3\n```\n"]], 
-         "ExpectedOutput" -> HoldForm[{"\n", 
-            MarkdownParse`MarkdownElement["CodeBlock", 
-             Association[
-             "Language" -> "None", "Body" -> "f[x]:=2;\nf[y]:=3"]], "\n"}], 
-         "ActualOutput" -> HoldForm[{"\n", 
-            MarkdownParse`MarkdownElement["CodeBlock", 
-             Association[
-             "Language" -> "None", "Body" -> "f[x]:=2;\nf[y]:=3"]], "\n"}], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000069`1.989364088569249, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00006800000000017903, "Seconds"], "MemoryUsed" -> 
-         Quantity[592, "Bytes"]]], 17 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 17, "TestID" -> "CodeBlockTest3", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[
-           Private`MarkdownParser, 
-            "\n    A generic code block\n    With some text\n"]], 
-         "ExpectedOutput" -> HoldForm[{"\n", 
-            MarkdownParse`MarkdownElement["CodeBlock", 
-             Association[
-             "Language" -> "None", "Body" -> 
-              "A generic code block\n    With some text\n"]]}], 
-         "ActualOutput" -> HoldForm[{"\n", 
-            MarkdownParse`MarkdownElement["CodeBlock", 
-             Association[
-             "Language" -> "None", "Body" -> 
-              "A generic code block\n    With some text\n"]]}], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.00005`1.849485002168013, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00004900000000018778, "Seconds"], "MemoryUsed" -> 
-         Quantity[576, "Bytes"]]], 18 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 18, "TestID" -> "InlineCodeTest1",
-          "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "`inline code`"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["InlineCode", "inline code"]], 
-         "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["InlineCode", "inline code"]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000059`1.9213670094741384, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.000058999999999809205`, "Seconds"], "MemoryUsed" -> 
-         Quantity[160, "Bytes"]]], 19 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 19, "TestID" -> "InlineCodeTest2",
-          "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[
-           Private`MarkdownParser, 
-            "insert inline `code block` formatting anywhere"]], 
-         "ExpectedOutput" -> HoldForm[{"insert inline ", 
-            MarkdownParse`MarkdownElement["InlineCode", "code block"], 
-            " formatting anywhere"}], "ActualOutput" -> 
-         HoldForm[{"insert inline ", 
-            MarkdownParse`MarkdownElement["InlineCode", "code block"], 
-            " formatting anywhere"}], "ExpectedMessages" -> {}, 
-         "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000083`2.069593090208068, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00008300000000005525, "Seconds"], "MemoryUsed" -> 
-         Quantity[312, "Bytes"]]], 20 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 20, "TestID" -> "InlineCodeTest3",
-          "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[
-           Private`MarkdownParser, 
-            "### A Chapter heading with `inline code` inserted"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["H3", {"A Chapter heading with ", 
-             MarkdownParse`MarkdownElement["InlineCode", "inline code"], 
-             " inserted"}]], "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["H3", {"A Chapter heading with ", 
-             MarkdownParse`MarkdownElement["InlineCode", "inline code"], 
-             " inserted"}]], "ExpectedMessages" -> {}, "ActualMessages" -> {},
-          "AbsoluteTimeUsed" -> 
-         Quantity[0.000239`2.5289128987801313, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0002369999999998207, "Seconds"], "MemoryUsed" -> 
-         Quantity[456, "Bytes"]]], 21 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 21, "TestID" -> 
-         "InlineLaTeXTest1", "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "\(a^2 + b^2 = c^2\)"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTeX", 
-            Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]], 
-         "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTeX", 
-            Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000043`1.7839834534115804, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00004300000000023729, "Seconds"], "MemoryUsed" -> 
-         Quantity[520, "Bytes"]]], 22 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 22, "TestID" -> 
-         "InlineLaTeXTest2", "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "$ a^2 + b^2 = c^2 $"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTeX", 
-            Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]], 
-         "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTeX", 
-            Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000041`1.7632988545517294, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00003900000000012227, "Seconds"], "MemoryUsed" -> 
-         Quantity[464, "Bytes"]]], 23 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 23, "TestID" -> 
-         "DisplayLaTeXTest1", "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "\\[ a^n + b^n = c^n \\]"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTeX", 
-            Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]], 
-         "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTeX", 
-            Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.00004`1.752574989159956, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00003900000000012227, "Seconds"], "MemoryUsed" -> 
-         Quantity[456, "Bytes"]]], 24 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 24, "TestID" -> 
-         "DisplayLaTeXTest2", "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "$$ a^2 + b^2 = c^2 $$"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTeX", 
-            Association["Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]],
-          "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTeX", 
-            Association["Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]],
-          "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 
-         Quantity[0.000041`1.763298854551729, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00003900000000012227, "Seconds"], "MemoryUsed" -> 
-         Quantity[464, "Bytes"]]], 25 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 25, "TestID" -> "LinkTest1", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[
-           Private`MarkdownParser, "[click here](www.google.com)"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement[Hyperlink, 
-            Association[
-            "Label" -> "click here", "Link" -> "www.google.com"]]], 
-         "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement[Hyperlink, 
-            Association[
-            "Label" -> "click here", "Link" -> "www.google.com"]]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000095`2.128238603120842, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00009400000000026054, "Seconds"], "MemoryUsed" -> 
-         Quantity[568, "Bytes"]]], 26 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 26, "TestID" -> "LinkTest2", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[Private`MarkdownParser, "<www.google.com>"]], 
-         "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement[Hyperlink, 
-            Association["Link" -> "www.google.com"]]], "ActualOutput" -> 
-         HoldForm[
-           MarkdownParse`MarkdownElement[Hyperlink, 
-            Association["Link" -> "www.google.com"]]], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000041`1.763298854551729, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00004099999999951365, "Seconds"], "MemoryUsed" -> 
-         Quantity[440, "Bytes"]]], 27 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 27, "TestID" -> "ImageLinkTest1", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[
-           Private`MarkdownParser, 
-            "![Streetview of Palm Trees by Brandon \
-Erlinger-Ford](https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
-ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
-format&fit=crop&w=564&q=80)"]], "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement[Hyperlink, 
-            Association[
-            "AltText" -> "Streetview of Palm Trees by Brandon Erlinger-Ford", 
-             "Link" -> 
-             "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
-ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
-format&fit=crop&w=564&q=80"]]], "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement[Hyperlink, 
-            Association[
-            "AltText" -> "Streetview of Palm Trees by Brandon Erlinger-Ford", 
-             "Link" -> 
-             "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
-ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
-format&fit=crop&w=564&q=80"]]], "ExpectedMessages" -> {}, 
-         "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000061`1.935844832842761, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00005999999999994898, "Seconds"], "MemoryUsed" -> 
-         Quantity[752, "Bytes"]]], 28 -> TestResultObject[
-        Association[
-        "TestClass" -> None, "TestIndex" -> 28, "TestID" -> "FoonoteTest1", 
-         "Outcome" -> "Success", "Input" -> HoldForm[
-           FixedPoint[
-           Private`MarkdownParser, 
-            "[The first footnote][1] was there and here's [the second \
-footnote][2]"]], "ExpectedOutput" -> HoldForm[{
-            MarkdownParse`MarkdownElement[Hyperlink, "The first footnote", 
-             MarkdownParse`MarkdownElement["FootnoteReference", {1}]], 
-            " was there and here's", 
-            MarkdownParse`MarkdownElement[Hyperlink, "the second footnote", 
-             MarkdownParse`MarkdownElement["FootnoteReference", {2}]]}], 
-         "ActualOutput" -> HoldForm[{
-            MarkdownParse`MarkdownElement[Hyperlink, "The first footnote", 
-             MarkdownParse`MarkdownElement["FootnoteReference", {1}]], 
-            " was there and here's", 
-            MarkdownParse`MarkdownElement[Hyperlink, "the second footnote", 
-             MarkdownParse`MarkdownElement["FootnoteReference", {2}]]}], 
-         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000166`2.370623085872049, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00016499999999997073`, "Seconds"], "MemoryUsed" -> 
-         Quantity[608, "Bytes"]]]], 
-    "TestsSucceededIndices" -> {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
-      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28}, 
-    "TestsFailedIndices" -> {}, "TestsFailedWrongResultsIndices" -> {}, 
-    "TestsFailedWithMessagesIndices" -> {}, 
-    "TestsFailedWithErrorsIndices" -> {}, "TimeElapsed" -> 
-    Quantity[0.003801`2.283254836092878, "Seconds"], "TestsSucceededCount" -> 
-    28, "TestsFailedCount" -> 0, "TestsFailedWrongResultsCount" -> 0, 
-    "TestsFailedWithMessagesCount" -> 0, "TestsFailedWithErrorsCount" -> 0, 
-    "Aborted" -> False]],
-  Editable->False,
-  SelectWithContents->True,
-  Selectable->False]], "Output",
- CellChangeTimes->{3.845226719611676*^9},
- CellLabel->"Out[12]=",ExpressionUUID->"03a2d32d-c89c-4f8a-83d7-c9ecf1566c64"]
 }, Open  ]]
-}, Open  ]],
+}, Closed]],
 
 Cell[CellGroupData[{
 
@@ -5167,11 +4501,11 @@ on other platforms."], "Tooltip"]& ]}}],
    3.83978660919948*^9},
  CellLabel->"Out[12]=",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
 }, Open  ]]
-}, Open  ]]
+}, Closed]]
 }, Open  ]]
 },
 WindowSize->{2560, 1387},
-WindowMargins->{{0, Automatic}, {Automatic, 0}},
+WindowMargins->{{0, Automatic}, {0, Automatic}},
 TaggingRules->{
  "WelcomeScreenSettings" -> {"FEStarting" -> False}, "TryRealOnly" -> False},
 FrontEndVersion->"12.3 for Mac OS X ARM (64-bit) (June 24, 2021)",
@@ -5194,54 +4528,48 @@ Cell[580, 22, 261, 4, 98, "Title",ExpressionUUID->"b7946855-acef-475d-bca3-4f6aa
 Cell[844, 28, 336, 5, 62, "Abstract",ExpressionUUID->"41f6fde2-3312-478f-b2c8-ff97b1cd3e62"],
 Cell[1183, 35, 249, 4, 35, "Text",ExpressionUUID->"ae62ea4f-43d4-4edf-903f-316f87708814"],
 Cell[1435, 41, 160, 3, 38, "CodeText",ExpressionUUID->"fea4a3a1-ea63-4863-a1c5-7652c6364503"],
-Cell[1598, 46, 177, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
-Cell[1778, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
-Cell[1968, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
-Cell[2236, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
-Cell[2518, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
-Cell[2735, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
-Cell[2930, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
+Cell[1598, 46, 176, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+Cell[1777, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
+Cell[1967, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
+Cell[2235, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
+Cell[2517, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
+Cell[2734, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
+Cell[2929, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
 Cell[CellGroupData[{
-Cell[3348, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
-Cell[3562, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
+Cell[3347, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
+Cell[3561, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
 Cell[CellGroupData[{
-Cell[3774, 103, 536, 12, 30, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
-Cell[4313, 117, 6350, 152, 403, "Output",ExpressionUUID->"9e8c8536-6d50-4b44-b5a1-3a64d5972403"]
+Cell[3773, 103, 536, 12, 30, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
+Cell[4312, 117, 6400, 153, 403, "Output",ExpressionUUID->"572dcb8e-5090-4ce3-81ef-7a6465304c32"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10712, 275, 265, 4, 67, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
-Cell[10980, 281, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
-Cell[11634, 296, 337, 6, 30, "Input",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
+Cell[10761, 276, 265, 4, 67, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
+Cell[11029, 282, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
+Cell[11683, 297, 337, 6, 30, "Input",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
 Cell[CellGroupData[{
-Cell[11996, 306, 511, 9, 30, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
-Cell[12510, 317, 477, 11, 101, "Echo",ExpressionUUID->"605c8bc1-821f-457c-a598-e40741ffbb34"]
+Cell[12045, 307, 511, 9, 30, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
+Cell[12559, 318, 409, 7, 101, "Echo",ExpressionUUID->"5e65cb7f-7e05-4941-9c71-bf937faeafb1"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[13024, 333, 264, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
-Cell[13291, 340, 24046, 548, 1431, "Output",ExpressionUUID->"f3c27957-ee9c-4018-9df1-23406b00f1a6"]
-}, Open  ]],
-Cell[37352, 891, 396, 10, 35, "Text",ExpressionUUID->"fd11d7bb-32c7-4cc0-b0ef-780fc0134e6d"],
-Cell[37751, 903, 1151, 24, 73, "Input",ExpressionUUID->"b263aba7-97b0-4acf-882c-d77f77a17c66"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[38939, 932, 157, 3, 67, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
-Cell[CellGroupData[{
-Cell[39121, 939, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
-Cell[39252, 942, 35105, 635, 63, "Output",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[74394, 1582, 129, 1, 30, "Input",ExpressionUUID->"d8839fb1-a010-4533-9172-beee3a24edf2"],
-Cell[74526, 1585, 33983, 618, 63, "Output",ExpressionUUID->"03a2d32d-c89c-4f8a-83d7-c9ecf1566c64"]
+Cell[13005, 330, 264, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
+Cell[13272, 337, 24081, 549, 1407, "Output",ExpressionUUID->"b5797c9a-9cde-4877-9304-0457ea6b3c8e"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[108558, 2209, 213, 4, 67, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
+Cell[37402, 892, 157, 3, 67, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
 Cell[CellGroupData[{
-Cell[108796, 2217, 504, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
-Cell[109303, 2228, 132096, 2939, 301, "Output",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
+Cell[37584, 899, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
+Cell[37715, 902, 35105, 635, 63, "Output",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
 }, Open  ]]
+}, Closed]],
+Cell[CellGroupData[{
+Cell[72869, 1543, 213, 4, 53, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
+Cell[CellGroupData[{
+Cell[73107, 1551, 504, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
+Cell[73614, 1562, 132096, 2939, 301, "Output",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
 }, Open  ]]
+}, Closed]]
 }, Open  ]]
 }
 ]

--- a/Parser/MarkdownParserDemo.nb
+++ b/Parser/MarkdownParserDemo.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    209069,       4569]
-NotebookOptionsPosition[    205750,       4506]
-NotebookOutlinePosition[    206237,       4524]
-CellTagsIndexPosition[    206194,       4521]
+NotebookDataLength[    213055,       4632]
+NotebookOptionsPosition[    209863,       4572]
+NotebookOutlinePosition[    210350,       4590]
+CellTagsIndexPosition[    210307,       4587]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -46,7 +46,7 @@ Cell["Quit the kernel", "CodeText",
 
 Cell[BoxData["Quit"], "Input",
  CellChangeTimes->{{3.817239754310732*^9, 3.8172397548456573`*^9}},
- CellLabel->"In[7]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+ CellLabel->"In[10]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
 
 Cell["Install the packages again from the Menu:", "Text",
  CellChangeTimes->{{3.8174165987397127`*^9, 
@@ -113,7 +113,7 @@ Cell[BoxData[
      RowBox[{"Frame", "\[Rule]", "All"}]}], "]"}], "&"}]}]], "Input",
  CellChangeTimes->{{3.8173380564205627`*^9, 3.817338059952167*^9}, {
   3.8173382937088327`*^9, 3.8173383261851873`*^9}},
- CellLabel->"In[9]:=",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
+ CellLabel->"In[3]:=",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
 
 Cell[BoxData[
  TagBox[GridBox[{
@@ -267,8 +267,9 @@ Cell[BoxData[
    3.839785419382757*^9, 3.8397854364402733`*^9}, {3.839785527027009*^9, 
    3.839785540844495*^9}, 3.839786014047813*^9, 3.8397862448168993`*^9, 
    3.845226378341282*^9, 3.84522716739851*^9, 3.845228657170726*^9, 
-   3.8452301157611837`*^9},
- CellLabel->"Out[9]=",ExpressionUUID->"572dcb8e-5090-4ce3-81ef-7a6465304c32"]
+   3.8452301157611837`*^9, 3.845231170412335*^9, 3.8452315315519876`*^9, 
+   3.845231831921571*^9, 3.8452323587209063`*^9},
+ CellLabel->"Out[3]=",ExpressionUUID->"4cd8466e-77c2-4d43-b854-9cf494ea4639"]
 }, Open  ]]
 }, Open  ]],
 
@@ -293,7 +294,7 @@ Cell[BoxData[
    3.817157937214015*^9}, {3.8172366531060762`*^9, 3.8172366534588127`*^9}, 
    3.817330653594535*^9, {3.81738967309939*^9, 3.817389685568739*^9}, {
    3.8173897935513268`*^9, 3.817389831975668*^9}},
- CellLabel->"In[3]:=",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
+ CellLabel->"In[4]:=",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
 
 Cell[BoxData[
  RowBox[{
@@ -301,9 +302,7 @@ Cell[BoxData[
    RowBox[{"filePath", ",", "\"\<Text\>\""}], "]"}], ";"}]], "Input",
  CellChangeTimes->{{3.839786671641347*^9, 3.8397867032127323`*^9}, {
    3.845226422574849*^9, 3.845226424824779*^9}, 3.845227179074463*^9},
- CellLabel->"In[4]:=",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
-
-Cell[CellGroupData[{
+ CellLabel->"In[5]:=",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
 
 Cell[BoxData[
  RowBox[{
@@ -314,17 +313,7 @@ Cell[BoxData[
    3.8171704049186897`*^9}, 3.8172358431384687`*^9, {3.817240946833456*^9, 
    3.81724094888334*^9}, 3.8172413585269203`*^9, {3.81734384974724*^9, 
    3.817343850827291*^9}},
- CellLabel->"In[5]:=",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
-
-Cell[BoxData["\<\"[1]: http://daringfireball.net/projects/markdown/\\n[2]: \
-http://www.fileformat.info/info/unicode/char/2163/index.htm\\n[3]: \
-http://www.markitdown.net/\\n[4]: \
-http://daringfireball.net/projects/markdown/basics\\n[5]: \
-http://daringfireball.net/projects/markdown/syntax\"\>"], "Echo",
- CellChangeTimes->{
-  3.845230439546041*^9},ExpressionUUID->"5e65cb7f-7e05-4941-9c71-\
-bf937faeafb1"]
-}, Open  ]],
+ CellLabel->"In[6]:=",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
 
 Cell[CellGroupData[{
 
@@ -333,7 +322,7 @@ Cell[BoxData[
   RowBox[{"mdp", ",", 
    RowBox[{"Frame", "\[Rule]", "All"}]}], "]"}]], "Input",
  CellChangeTimes->{{3.817333311218748*^9, 3.817333316916204*^9}},
- CellLabel->"In[6]:=",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
+ CellLabel->"In[7]:=",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
 
 Cell[BoxData[
  TagBox[GridBox[{
@@ -883,8 +872,10 @@ in rendering on other platforms.\"\>"}], "}"}]}
    3.83978561192607*^9, {3.839786021507169*^9, 3.839786026115018*^9}, 
    3.839786250526957*^9, 3.8452264595099916`*^9, 3.845227189799056*^9, 
    3.845228682065586*^9, 3.845230086802711*^9, 3.845230183075725*^9, 
-   3.8452303148139267`*^9, 3.845230353618988*^9, 3.845230440854608*^9},
- CellLabel->"Out[6]=",ExpressionUUID->"b5797c9a-9cde-4877-9304-0457ea6b3c8e"]
+   3.8452303148139267`*^9, 3.845230353618988*^9, 3.845230440854608*^9, 
+   3.8452311758511*^9, 3.845231535703302*^9, 3.8452318357795467`*^9, 
+   3.8452323639790163`*^9},
+ CellLabel->"Out[7]=",ExpressionUUID->"e2e7d7cc-466f-469f-b259-34f26219b407"]
 }, Open  ]]
 }, Open  ]],
 
@@ -898,7 +889,7 @@ fc1c63394988"],
 Cell[CellGroupData[{
 
 Cell[BoxData["MarkdownParserTestReport"], "Input",
- CellLabel->"In[7]:=",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
+ CellLabel->"In[8]:=",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -954,7 +945,7 @@ Cell[BoxData[
                RowBox[{
                  TagBox["\"Tests run: \"", "SummaryItemAnnotation"], 
                  "\[InvisibleSpace]", 
-                 TagBox["28", "SummaryItem"]}]}}, AutoDelete -> False, 
+                 TagBox["32", "SummaryItem"]}]}}, AutoDelete -> False, 
              BaseStyle -> {
               ShowStringCharacters -> False, NumberMarks -> False, 
                PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
@@ -1014,11 +1005,11 @@ Cell[BoxData[
                RowBox[{
                  TagBox["\"Tests run: \"", "SummaryItemAnnotation"], 
                  "\[InvisibleSpace]", 
-                 TagBox["28", "SummaryItem"]}]}, {
+                 TagBox["32", "SummaryItem"]}]}, {
                RowBox[{
                  TagBox["\"Succeeded: \"", "SummaryItemAnnotation"], 
                  "\[InvisibleSpace]", 
-                 TagBox["28", "SummaryItem"]}], "\[SpanFromLeft]"}, {
+                 TagBox["32", "SummaryItem"]}], "\[SpanFromLeft]"}, {
                RowBox[{
                  TagBox["\"Failed: \"", "SummaryItemAnnotation"], 
                  "\[InvisibleSpace]", 
@@ -1043,8 +1034,8 @@ Cell[BoxData[
                  TagBox[
                   
                   TemplateBox[{
-                   "0.0036930000000000002`2.2707362741407513", "\"s\"", 
-                    "seconds", "\"Seconds\""}, "Quantity"], "SummaryItem"]}], 
+                   "0.004107`2.2588897223657383", "\"s\"", "seconds", 
+                    "\"Seconds\""}, "Quantity"], "SummaryItem"]}], 
                "\[SpanFromLeft]"}}, AutoDelete -> False, 
              BaseStyle -> {
               ShowStringCharacters -> False, NumberMarks -> False, 
@@ -1074,9 +1065,9 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement["H1", "A Title"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000222`2.496867972282628, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00022300000000008424`, "Seconds"], "MemoryUsed" -> 
-         Quantity[30400, "Bytes"]]], 2 -> TestResultObject[
+         Quantity[0.000228`2.5084498448324433, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.0002309999999994261, "Seconds"], "MemoryUsed" -> 
+         Quantity[31392, "Bytes"]]], 2 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 2, "TestID" -> "H2Test", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1086,9 +1077,9 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement["H2", "A Subtitle"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000111`2.195837976618649, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010899999999969268`, "Seconds"], "MemoryUsed" -> 
-         Quantity[584, "Bytes"]]], 3 -> TestResultObject[
+         Quantity[0.000115`2.2112128381856015, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00011399999999994748`, "Seconds"], "MemoryUsed" -> 
+         Quantity[496, "Bytes"]]], 3 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 3, "TestID" -> "H3Test", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1098,9 +1089,9 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement["H3", "A Chapter"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000109`2.1879414957726175, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010799999999999699`, "Seconds"], "MemoryUsed" -> 
-         Quantity[192, "Bytes"]]], 4 -> TestResultObject[
+         Quantity[0.000113`2.2035934413154115, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00011199999999966792`, "Seconds"], "MemoryUsed" -> 
+         Quantity[264, "Bytes"]]], 4 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 4, "TestID" -> "H4Test", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1110,9 +1101,9 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement["H4", "A Section"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000103`2.1633522225371657, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010300000000018628`, "Seconds"], "MemoryUsed" -> 
-         Quantity[192, "Bytes"]]], 5 -> TestResultObject[
+         Quantity[0.000108`2.1839387533189436, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010900000000013677`, "Seconds"], "MemoryUsed" -> 
+         Quantity[248, "Bytes"]]], 5 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 5, "TestID" -> "H5Test", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1122,8 +1113,8 @@ Cell[BoxData[
          "ActualOutput" -> HoldForm[
            MarkdownParse`MarkdownElement["H5", "A Subsection"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000107`2.1798987755172035, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010699999999941312`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000109`2.1879414957726135, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010699999999985721`, "Seconds"], "MemoryUsed" -> 
          Quantity[192, "Bytes"]]], 6 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 6, "TestID" -> "H6Test", 
@@ -1134,8 +1125,8 @@ Cell[BoxData[
          "ActualOutput" -> HoldForm[
            MarkdownParse`MarkdownElement["H6", "A Subsubsection"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000105`2.171704296901932, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010500000000046583`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000111`2.1958379766186518, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00011200000000011201`, "Seconds"], "MemoryUsed" -> 
          Quantity[192, "Bytes"]]], 7 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 7, "TestID" -> "HNTest", 
@@ -1144,8 +1135,8 @@ Cell[BoxData[
          "ExpectedOutput" -> HoldForm["####### A Paragraph"], "ActualOutput" -> 
          HoldForm["####### A Paragraph"], "ExpectedMessages" -> {}, 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000036`1.706817498599281, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00003500000000000725, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000037`1.7187167218989845, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000036999999999842714`, "Seconds"], "MemoryUsed" -> 
          Quantity[112, "Bytes"]]], 8 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 8, "TestID" -> "ItalicTest1", 
@@ -1156,8 +1147,8 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement[Italic, "test"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000101`2.154836371614637, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00009900000000007125, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000101`2.1548363716146346, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00009999999999976694, "Seconds"], "MemoryUsed" -> 
          Quantity[152, "Bytes"]]], 9 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 9, "TestID" -> "ItalicTest2", 
@@ -1168,9 +1159,9 @@ Cell[BoxData[
          HoldForm[{"this is a ", 
             MarkdownParse`MarkdownElement[Italic, "test"]}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000085`2.079933923546286, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00008400000000019503, "Seconds"], "MemoryUsed" -> 
-         Quantity[248, "Bytes"]]], 10 -> TestResultObject[
+         Quantity[0.000091`2.1095563901530854, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00008900000000000574, "Seconds"], "MemoryUsed" -> 
+         Quantity[312, "Bytes"]]], 10 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 10, "TestID" -> "ItalicTest3", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1181,9 +1172,9 @@ Cell[BoxData[
             MarkdownParse`MarkdownElement[Italic, "different kind"], 
             " of test"}], "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
          "AbsoluteTimeUsed" -> 
-         Quantity[0.000106`2.175820863096762, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00010600000000016152`, "Seconds"], "MemoryUsed" -> 
-         Quantity[296, "Bytes"]]], 11 -> TestResultObject[
+         Quantity[0.000113`2.2035934413154137, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010899999999969268`, "Seconds"], "MemoryUsed" -> 
+         Quantity[368, "Bytes"]]], 11 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 11, "TestID" -> "ItalicTest4", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1199,9 +1190,9 @@ Cell[BoxData[
             MarkdownParse`MarkdownElement[Bold, "different"], " ", 
             MarkdownParse`MarkdownElement[Italic, "kind"], " of test"}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000197`2.4449812239935844, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00019700000000000273`, "Seconds"], "MemoryUsed" -> 
-         Quantity[576, "Bytes"]]], 12 -> TestResultObject[
+         Quantity[0.000204`2.4601451652578903, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00020400000000053709`, "Seconds"], "MemoryUsed" -> 
+         Quantity[720, "Bytes"]]], 12 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 12, "TestID" -> "ItalicTest5", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1213,9 +1204,9 @@ Cell[BoxData[
             MarkdownParse`MarkdownElement[Italic, 
              MarkdownParse`MarkdownElement[Bold, "mixed bag"]], " test"}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000203`2.458011035745205, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00020199999999981344`, "Seconds"], "MemoryUsed" -> 
-         Quantity[496, "Bytes"]]], 13 -> TestResultObject[
+         Quantity[0.00022`2.4929376786542004, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00021800000000027353`, "Seconds"], "MemoryUsed" -> 
+         Quantity[480, "Bytes"]]], 13 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 13, "TestID" -> "BlockQuoteTest1",
           "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1228,8 +1219,8 @@ Cell[BoxData[
              MarkdownParse`MarkdownElement[Italic, "block quote"], " test"}]],
           "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
          "AbsoluteTimeUsed" -> 
-         Quantity[0.000199`2.449368074241699, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00019999999999997797`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000207`2.4664853432889076, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00020499999999978868`, "Seconds"], "MemoryUsed" -> 
          Quantity[344, "Bytes"]]], 14 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 14, "TestID" -> "TableTest1", 
@@ -1265,9 +1256,9 @@ Cell[BoxData[
                MarkdownParse`MarkdownElement[
                "TableRow", {"1 ", " 2 ", " 3"}]}}]}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000947`3.126864976835263, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0009429999999999161, "Seconds"], "MemoryUsed" -> 
-         Quantity[30224, "Bytes"]]], 15 -> TestResultObject[
+         Quantity[0.000943`3.1250266905693223, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.0009449999999997516, "Seconds"], "MemoryUsed" -> 
+         Quantity[30304, "Bytes"]]], 15 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 15, "TestID" -> "CodeBlockTest1", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1284,9 +1275,9 @@ Cell[BoxData[
              "Language" -> "Mathematica", "Body" -> "f[x]:=2;\nf[y]:=3"]], 
             "\n"}], "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
          "AbsoluteTimeUsed" -> 
-         Quantity[0.000074`2.0197467175629678, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000075`2.0255762612236894, "Seconds"], "CPUTimeUsed" -> 
          Quantity[0.00007400000000012952, "Seconds"], "MemoryUsed" -> 
-         Quantity[632, "Bytes"]]], 16 -> TestResultObject[
+         Quantity[768, "Bytes"]]], 16 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 16, "TestID" -> "CodeBlockTest2", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1302,7 +1293,7 @@ Cell[BoxData[
              "Language" -> "None", "Body" -> "f[x]:=2;\nf[y]:=3"]], "\n"}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
          Quantity[0.000069`1.9893640885692467, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0000690000000003188, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.00006899999999987472, "Seconds"], "MemoryUsed" -> 
          Quantity[592, "Bytes"]]], 17 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 17, "TestID" -> "CodeBlockTest3", 
@@ -1321,8 +1312,8 @@ Cell[BoxData[
              "Language" -> "None", "Body" -> 
               "A generic code block\n    With some text\n"]]}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000045`1.8037275116073337, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.000042999999999793204`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000048`1.831756235207579, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004900000000063187, "Seconds"], "MemoryUsed" -> 
          Quantity[576, "Bytes"]]], 18 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 18, "TestID" -> "InlineCodeTest1",
@@ -1333,8 +1324,8 @@ Cell[BoxData[
          "ActualOutput" -> HoldForm[
            MarkdownParse`MarkdownElement["InlineCode", "inline code"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000056`1.898703024838192, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00005599999999983396, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000058`1.9139429913949293, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00005699999999997374, "Seconds"], "MemoryUsed" -> 
          Quantity[160, "Bytes"]]], 19 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 19, "TestID" -> "InlineCodeTest2",
@@ -1349,8 +1340,8 @@ Cell[BoxData[
             MarkdownParse`MarkdownElement["InlineCode", "code block"], 
             " formatting anywhere"}], "ExpectedMessages" -> {}, 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000075`2.0255762612236934, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00007599999999996498, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000081`2.0590000167106437, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00008000000000008001, "Seconds"], "MemoryUsed" -> 
          Quantity[312, "Bytes"]]], 20 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 20, "TestID" -> "InlineCodeTest3",
@@ -1366,8 +1357,8 @@ Cell[BoxData[
              MarkdownParse`MarkdownElement["InlineCode", "inline code"], 
              " inserted"}]], "ExpectedMessages" -> {}, "ActualMessages" -> {},
           "AbsoluteTimeUsed" -> 
-         Quantity[0.000228`2.5084498448324477, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0002300000000001745, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000237`2.5252633438420955, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00023499999999998522`, "Seconds"], "MemoryUsed" -> 
          Quantity[456, "Bytes"]]], 21 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 21, "TestID" -> 
@@ -1380,8 +1371,8 @@ Cell[BoxData[
            MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000042`1.7737642882298899, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00004400000000037707, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000043`1.78398345341158, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004099999999995774, "Seconds"], "MemoryUsed" -> 
          Quantity[456, "Bytes"]]], 22 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 22, "TestID" -> 
@@ -1394,8 +1385,8 @@ Cell[BoxData[
            MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000041`1.7632988545517252, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00004099999999995774, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.00004`1.752574989159956, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000042000000000097515`, "Seconds"], "MemoryUsed" -> 
          Quantity[464, "Bytes"]]], 23 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 23, "TestID" -> 
@@ -1408,7 +1399,7 @@ Cell[BoxData[
            MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.00004`1.7525749891599518, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004`1.752574989159954, "Seconds"], "CPUTimeUsed" -> 
          Quantity[0.00004000000000026205, "Seconds"], "MemoryUsed" -> 
          Quantity[456, "Bytes"]]], 24 -> TestResultObject[
         Association[
@@ -1423,8 +1414,8 @@ Cell[BoxData[
             Association["Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]],
           "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
          "AbsoluteTimeUsed" -> 
-         Quantity[0.000039`1.7415796048584888, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.000036999999999842714`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000041`1.7632988545517252, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004099999999951365, "Seconds"], "MemoryUsed" -> 
          Quantity[464, "Bytes"]]], 25 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 25, "TestID" -> "LinkTest1", 
@@ -1440,8 +1431,8 @@ Cell[BoxData[
             Association[
             "Label" -> "click here", "Link" -> "www.google.com"]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000091`2.1095563901530854, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00008999999999925734, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000095`2.1282386031208413, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00009499999999995623, "Seconds"], "MemoryUsed" -> 
          Quantity[496, "Bytes"]]], 26 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 26, "TestID" -> "LinkTest2", 
@@ -1454,8 +1445,8 @@ Cell[BoxData[
            MarkdownParse`MarkdownElement[Hyperlink, 
             Association["Link" -> "www.google.com"]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.00004`1.752574989159956, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00003900000000012227, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000042`1.7737642882298943, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000041000000000401826`, "Seconds"], "MemoryUsed" -> 
          Quantity[368, "Bytes"]]], 27 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 27, "TestID" -> "ImageLinkTest1", 
@@ -1481,9 +1472,9 @@ format&fit=crop&w=564&q=80"]]], "ActualOutput" -> HoldForm[
 ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
 format&fit=crop&w=564&q=80"]]], "ExpectedMessages" -> {}, 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000062`1.9429066873302476, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.000058000000000113516`, "Seconds"], "MemoryUsed" -> 
-         Quantity[752, "Bytes"]]], 28 -> TestResultObject[
+         Quantity[0.000061`1.9358448328427589, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00006200000000022854, "Seconds"], "MemoryUsed" -> 
+         Quantity[680, "Bytes"]]], 28 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 28, "TestID" -> "FoonoteTest1", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1503,18 +1494,92 @@ footnote][2]"]], "ExpectedOutput" -> HoldForm[{
             MarkdownParse`MarkdownElement[Hyperlink, "the second footnote", 
              MarkdownParse`MarkdownElement["FootnoteReference", {2}]]}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.00016`2.3546349804879183, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00015999999999971593`, "Seconds"], "MemoryUsed" -> 
-         Quantity[608, "Bytes"]]]], 
+         Quantity[0.000173`2.3885611009607874, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.0001710000000003653, "Seconds"], "MemoryUsed" -> 
+         Quantity[608, "Bytes"]]], 29 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 29, "TestID" -> 
+         "UnorderedItemTest1", "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "* This is an unordered item"]],
+          "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["Item", 
+            Association[
+            "Type" -> "Unordered", "IndentationLevel" -> 0, "IndentationType" -> 
+             None, "Content" -> "This is an unordered item"]]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["Item", 
+            Association[
+            "Type" -> "Unordered", "IndentationLevel" -> 0, "IndentationType" -> 
+             None, "Content" -> "This is an unordered item"]]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000097`2.1372867320982385, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00009900000000007125, "Seconds"], "MemoryUsed" -> 
+         Quantity[648, "Bytes"]]], 30 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 30, "TestID" -> 
+         "UnorderedItemTest2", "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, "  * here is an unordered sub item"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["Item", 
+            Association[
+            "Type" -> "Unordered", "IndentationLevel" -> 1, "IndentationType" -> 
+             "Whitespace", "Content" -> "here is an unordered sub item"]]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["Item", 
+            Association[
+            "Type" -> "Unordered", "IndentationLevel" -> 1, "IndentationType" -> 
+             "Whitespace", "Content" -> "here is an unordered sub item"]]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000115`2.2112128381856055, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00011099999999997223`, "Seconds"], "MemoryUsed" -> 
+         Quantity[1256, "Bytes"]]], 31 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 31, "TestID" -> 
+         "OrderedItemTest1", "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[Private`MarkdownParser, "1. This is an ordered item"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["Item", 
+            Association[
+            "Type" -> "Ordered", "IndentationLevel" -> 0, "IndentationType" -> 
+             None, "Content" -> "This is an ordered item"]]], "ActualOutput" -> 
+         HoldForm[
+           MarkdownParse`MarkdownElement["Item", 
+            Association[
+            "Type" -> "Ordered", "IndentationLevel" -> 0, "IndentationType" -> 
+             None, "Content" -> "This is an ordered item"]]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000045`1.8037275116073337, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004500000000007276, "Seconds"], "MemoryUsed" -> 
+         Quantity[704, "Bytes"]]], 32 -> TestResultObject[
+        Association[
+        "TestClass" -> None, "TestIndex" -> 32, "TestID" -> 
+         "OrderedItemTest2", "Outcome" -> "Success", "Input" -> HoldForm[
+           FixedPoint[
+           Private`MarkdownParser, "  1. here is an ordered sub item"]], 
+         "ExpectedOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["Item", 
+            Association[
+            "Type" -> "Ordered", "IndentationLevel" -> 1, "IndentationType" -> 
+             "Whitespace", "Content" -> "here is an ordered sub item"]]], 
+         "ActualOutput" -> HoldForm[
+           MarkdownParse`MarkdownElement["Item", 
+            Association[
+            "Type" -> "Ordered", "IndentationLevel" -> 1, "IndentationType" -> 
+             "Whitespace", "Content" -> "here is an ordered sub item"]]], 
+         "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
+         Quantity[0.000047`1.8226128557677073, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004900000000018778, "Seconds"], "MemoryUsed" -> 
+         Quantity[712, "Bytes"]]]], 
     "TestsSucceededIndices" -> {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
-      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28}, 
-    "TestsFailedIndices" -> {}, "TestsFailedWrongResultsIndices" -> {}, 
+      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+     "TestsFailedIndices" -> {}, "TestsFailedWrongResultsIndices" -> {}, 
     "TestsFailedWithMessagesIndices" -> {}, 
     "TestsFailedWithErrorsIndices" -> {}, "TimeElapsed" -> 
-    Quantity[0.0036930000000000002`2.2707362741407513, "Seconds"], 
-    "TestsSucceededCount" -> 28, "TestsFailedCount" -> 0, 
-    "TestsFailedWrongResultsCount" -> 0, "TestsFailedWithMessagesCount" -> 0, 
-    "TestsFailedWithErrorsCount" -> 0, "Aborted" -> False]],
+    Quantity[0.004107`2.2588897223657383, "Seconds"], "TestsSucceededCount" -> 
+    32, "TestsFailedCount" -> 0, "TestsFailedWrongResultsCount" -> 0, 
+    "TestsFailedWithMessagesCount" -> 0, "TestsFailedWithErrorsCount" -> 0, 
+    "Aborted" -> False]],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output",
@@ -1534,10 +1599,11 @@ footnote][2]"]], "ExpectedOutput" -> HoldForm[{
    3.817413740261161*^9, 3.817413987525134*^9, 3.817414184435028*^9, 
    3.817414459927204*^9, 3.8174145345787983`*^9, 3.8174157551387587`*^9, 
    3.8174159839662447`*^9, 3.817416073446569*^9, 3.8174164180390863`*^9, 
-   3.839786422508462*^9},
- CellLabel->"Out[7]=",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
+   3.839786422508462*^9, 3.845231181309247*^9, 3.8452315407023697`*^9, 
+   3.845231665537881*^9, 3.845231843939288*^9, 3.845232375138321*^9},
+ CellLabel->"Out[8]=",ExpressionUUID->"292a713b-5243-4024-8987-071c2bb6bbea"]
 }, Open  ]]
-}, Closed]],
+}, Open  ]],
 
 Cell[CellGroupData[{
 
@@ -4528,46 +4594,43 @@ Cell[580, 22, 261, 4, 98, "Title",ExpressionUUID->"b7946855-acef-475d-bca3-4f6aa
 Cell[844, 28, 336, 5, 62, "Abstract",ExpressionUUID->"41f6fde2-3312-478f-b2c8-ff97b1cd3e62"],
 Cell[1183, 35, 249, 4, 35, "Text",ExpressionUUID->"ae62ea4f-43d4-4edf-903f-316f87708814"],
 Cell[1435, 41, 160, 3, 38, "CodeText",ExpressionUUID->"fea4a3a1-ea63-4863-a1c5-7652c6364503"],
-Cell[1598, 46, 176, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
-Cell[1777, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
-Cell[1967, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
-Cell[2235, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
-Cell[2517, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
-Cell[2734, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
-Cell[2929, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
+Cell[1598, 46, 177, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+Cell[1778, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
+Cell[1968, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
+Cell[2236, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
+Cell[2518, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
+Cell[2735, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
+Cell[2930, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
 Cell[CellGroupData[{
-Cell[3347, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
-Cell[3561, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
+Cell[3348, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
+Cell[3562, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
 Cell[CellGroupData[{
-Cell[3773, 103, 536, 12, 30, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
-Cell[4312, 117, 6400, 153, 403, "Output",ExpressionUUID->"572dcb8e-5090-4ce3-81ef-7a6465304c32"]
+Cell[3774, 103, 536, 12, 30, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
+Cell[4313, 117, 6496, 154, 403, "Output",ExpressionUUID->"4cd8466e-77c2-4d43-b854-9cf494ea4639"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10761, 276, 265, 4, 67, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
-Cell[11029, 282, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
-Cell[11683, 297, 337, 6, 30, "Input",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
+Cell[10858, 277, 265, 4, 67, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
+Cell[11126, 283, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
+Cell[11780, 298, 337, 6, 30, "Input",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
+Cell[12120, 306, 511, 9, 30, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
 Cell[CellGroupData[{
-Cell[12045, 307, 511, 9, 30, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
-Cell[12559, 318, 409, 7, 101, "Echo",ExpressionUUID->"5e65cb7f-7e05-4941-9c71-bf937faeafb1"]
-}, Open  ]],
-Cell[CellGroupData[{
-Cell[13005, 330, 264, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
-Cell[13272, 337, 24081, 549, 1407, "Output",ExpressionUUID->"b5797c9a-9cde-4877-9304-0457ea6b3c8e"]
+Cell[12656, 319, 264, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
+Cell[12923, 326, 24179, 551, 1407, "Output",ExpressionUUID->"e2e7d7cc-466f-469f-b259-34f26219b407"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[37402, 892, 157, 3, 67, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
+Cell[37151, 883, 157, 3, 67, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
 Cell[CellGroupData[{
-Cell[37584, 899, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
-Cell[37715, 902, 35105, 635, 63, "Output",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
+Cell[37333, 890, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
+Cell[37464, 893, 39469, 710, 63, "Output",ExpressionUUID->"292a713b-5243-4024-8987-071c2bb6bbea"]
 }, Open  ]]
-}, Closed]],
+}, Open  ]],
 Cell[CellGroupData[{
-Cell[72869, 1543, 213, 4, 53, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
+Cell[76982, 1609, 213, 4, 67, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
 Cell[CellGroupData[{
-Cell[73107, 1551, 504, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
-Cell[73614, 1562, 132096, 2939, 301, "Output",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
+Cell[77220, 1617, 504, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
+Cell[77727, 1628, 132096, 2939, 301, "Output",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
 }, Open  ]]
 }, Closed]]
 }, Open  ]]

--- a/Parser/MarkdownParserDemo.nb
+++ b/Parser/MarkdownParserDemo.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    194229,       4285]
-NotebookOptionsPosition[    191130,       4226]
-NotebookOutlinePosition[    191619,       4244]
-CellTagsIndexPosition[    191576,       4241]
+NotebookDataLength[    207034,       4498]
+NotebookOptionsPosition[    203521,       4433]
+NotebookOutlinePosition[    204007,       4451]
+CellTagsIndexPosition[    203964,       4448]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -46,7 +46,7 @@ Cell["Quit the kernel", "CodeText",
 
 Cell[BoxData["Quit"], "Input",
  CellChangeTimes->{{3.817239754310732*^9, 3.8172397548456573`*^9}},
- CellLabel->"In[4]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+ CellLabel->"In[32]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
 
 Cell["Install the packages again from the Menu:", "Text",
  CellChangeTimes->{{3.8174165987397127`*^9, 
@@ -113,7 +113,7 @@ Cell[BoxData[
      RowBox[{"Frame", "\[Rule]", "All"}]}], "]"}], "&"}]}]], "Input",
  CellChangeTimes->{{3.8173380564205627`*^9, 3.817338059952167*^9}, {
   3.8173382937088327`*^9, 3.8173383261851873`*^9}},
- CellLabel->"In[8]:=",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
+ CellLabel->"In[3]:=",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
 
 Cell[BoxData[
  TagBox[GridBox[{
@@ -128,7 +128,7 @@ Cell[BoxData[
       RowBox[{"Italic", ",", "\"\<$2\>\""}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\"\<LaTex\>\"", ",", 
+      RowBox[{"\"\<LaTeX\>\"", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
          RowBox[{"\"\<Type\>\"", "\[Rule]", "\"\<Display\>\""}], ",", 
@@ -136,7 +136,7 @@ Cell[BoxData[
         "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\"\<LaTex\>\"", ",", 
+      RowBox[{"\"\<LaTeX\>\"", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
          RowBox[{"\"\<Type\>\"", "\[Rule]", "\"\<Display\>\""}], ",", 
@@ -144,7 +144,7 @@ Cell[BoxData[
         "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\"\<LaTex\>\"", ",", 
+      RowBox[{"\"\<LaTeX\>\"", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
          RowBox[{"\"\<Type\>\"", "\[Rule]", "\"\<Inline\>\""}], ",", 
@@ -152,7 +152,7 @@ Cell[BoxData[
         "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\"\<LaTex\>\"", ",", 
+      RowBox[{"\"\<LaTeX\>\"", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
          RowBox[{"\"\<Type\>\"", "\[Rule]", "\"\<Inline\>\""}], ",", 
@@ -160,7 +160,7 @@ Cell[BoxData[
         "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\"\<LaTex\>\"", ",", 
+      RowBox[{"\"\<LaTeX\>\"", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
          RowBox[{"\"\<Type\>\"", "\[Rule]", "\"\<Inline\>\""}], ",", 
@@ -200,7 +200,14 @@ Cell[BoxData[
        RowBox[{"{", "$1", "}"}], ",", "\"\<$2\>\""}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\"\<Item\>\"", ",", "\"\<$4\>\""}], "]"}]},
+      RowBox[{"\"\<Item\>\"", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\"\<IndentationLevel\>\"", "\[Rule]", "1"}], ",", 
+         RowBox[{"\"\<IndentationType\>\"", "\[Rule]", "\"\<Whitespace\>\""}],
+          ",", 
+         RowBox[{"\"\<Content\>\"", "\[Rule]", "\"\<$2\>\""}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"\"\<BlockQuote\>\"", ",", "\"\<$1\>\""}], "]"}]},
@@ -248,10 +255,12 @@ Cell[BoxData[
    3.817342897522029*^9, 3.8173430850560427`*^9, 3.8173437025203114`*^9, 
    3.817344121259778*^9, 3.817345136646003*^9, 3.817345467071245*^9, 
    3.817346450554831*^9, 3.817346621485446*^9, 3.81734675276777*^9, 
-   3.817389589946957*^9, 3.817423982038066*^9},
- CellLabel->"Out[8]=",ExpressionUUID->"a546dc40-7ffc-4fb1-946d-ce4e69710ee7"]
+   3.817389589946957*^9, 3.817423982038066*^9, 3.8397853572118587`*^9, {
+   3.839785419382757*^9, 3.8397854364402733`*^9}, {3.839785527027009*^9, 
+   3.839785540844495*^9}, 3.839786014047813*^9, 3.8397862448168993`*^9},
+ CellLabel->"Out[3]=",ExpressionUUID->"9d30d1e1-3b38-4327-b7fa-5f15a0c5141e"]
 }, Open  ]]
-}, Closed]],
+}, Open  ]],
 
 Cell[CellGroupData[{
 
@@ -275,6 +284,67 @@ Cell[BoxData[
    3.817330653594535*^9, {3.81738967309939*^9, 3.817389685568739*^9}, {
    3.8173897935513268`*^9, 3.817389831975668*^9}},
  CellLabel->"In[4]:=",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"Import", "[", 
+  RowBox[{"filePath", ",", "\"\<String\>\""}], "]"}]], "Input",
+ CellChangeTimes->{{3.839786671641347*^9, 3.8397867032127323`*^9}},
+ CellLabel->"In[19]:=",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
+
+Cell[BoxData["\<\"# An exhibit of Markdown\\n\\nThis note demonstrates some \
+of what [Markdown][1] is capable of doing.\\n\\n_Note: Feel free to play with \
+this page. Unlike regular notes, this doesn't automatically save \
+itself._\\n\\n## Basic formatting\\n\\nWrite Paragraphs like so. A paragraph \
+is the basic block of Markdown. A paragraph is what text will turn into when \
+there is no reason it should become anything else.\\n\\nBlank lines separate \
+paragraphs. Markdown supports _italic_ and **bold** formatting.\\n\\nLines \
+can have nested styling as well, like _a **bold** in an italic_.\\n\\n## \
+Lists\\n\\n### Ordered list\\n\\n1. Item 1\\n2. A second item\\n3. Number \
+3\\n4. \[AHat]\.85\[Sterling]\\n\\n_Note: the fourth item uses the Unicode \
+character for [Roman numeral four][2]._\\n\\n### Unordered list\\n\\n* An \
+item\\n* Another item\\n* Yet another item\\n* And there's more...\\n\\n## \
+Paragraph modifiers\\n\\n### Code block\\n\\n    Code blocks are useful for \
+people who look at code or for clarity of plain text content. As you can see, \
+it uses a fixed-width font.\\n\\nYou can also make `inline code` to add \
+insert code block formatting anywhere.\\n\\n### Quote\\n\\n> Here is a quote. \
+What this is should be self explanatory. Quotes are automatically indented \
+when they are used.\\n\\n## Headings\\n\\nMarkdown supports six levels of \
+headings; corresponding with the six levels of HTML headings. You've probably \
+noticed them already in the page. Each level down uses one more hash \
+character.\\n\\n### Headings _can_ also contain **formatting**\\n\\n### They \
+can even contain `inline code`\\n\\nOf course, demonstrating what headings \
+look like messes up the structure of the page.\\n\\nI don't recommend using \
+more than three or four levels of headings here, because, when you're \
+smallest heading isn't too small, and you're largest heading isn't too big, \
+and you want each size up to look noticeably larger and more important, there \
+aren't any other sizes to choose from.\\n\\n## LaTex\\n\\nLaTex is also \
+supported:\\n\\n* inline\\n\\n\\\\(a^2 + b^2 = c^2\\\\)\\n\\n$ a^2 + b^2 = \
+c^2 $\\n\\n* presented\\n\\n\\\\[ a^n + b^n = c^n \\\\]\\n\\n$$ a^2 + b^2 = \
+c^2 $$\\n\\n\\n## URLs\\n\\nAdd hyperlinks in the following ways:\\n\\n* A \
+named link to [MarkItDown][3]. The easiest way to do these is to select what \
+you want to make a link and hit `Ctrl+L`.\\n* Another named link to \
+[MarkItDown](http://www.markitdown.net/)\\n* Sometimes you want the URL : \
+<http://www.markitdown.net/>.\\n\\n## Horizontal rule\\n\\nA horizontal rule \
+is a dividing line drawn across the page, useful for separating blocks of \
+text.\\n\\n---\\n\\n## Tables\\n\\nMarkdown | Less | Pretty\\n--- | --- | ---\
+\\n*Still* | `renders` | **nicely**\\n1 | 2 | 3\\n\\n## Images\\n\\nMarkdown \
+can also contain images.\\n![Streetview of Palm Trees by Brandon \
+Erlinger-Ford](https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
+ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
+format&fit=crop&w=564&q=80)\\n\\n## Last\\n\\nThere's actually a lot more to \
+Markdown than this. See the official [introduction][4] and [syntax][5] for \
+more information. Be aware that this document is not using the official \
+implementation, and there may be subtle differences in rendering on other \
+platforms.\\n\\n\\n  [1]: http://daringfireball.net/projects/markdown/\\n  \
+[2]: http://www.fileformat.info/info/unicode/char/2163/index.htm\\n  [3]: \
+http://www.markitdown.net/\\n  [4]: \
+http://daringfireball.net/projects/markdown/basics\\n  [5]: \
+http://daringfireball.net/projects/markdown/syntax\\n\"\>"], "Output",
+ CellChangeTimes->{{3.839786672681287*^9, 3.839786703609291*^9}},
+ CellLabel->"Out[19]=",ExpressionUUID->"1c788981-27b2-4fe6-a8a9-38507ecb363b"]
+}, Open  ]],
 
 Cell[BoxData[
  RowBox[{
@@ -381,16 +451,41 @@ http://www.fileformat.info/info/unicode/char/2163/index.htm\"\>"}], "]"}],
       RowBox[{"\<\"H3\"\>", ",", "\<\"Unordered list\"\>"}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"Item\"\>", ",", "\<\"An item\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"An item\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"Item\"\>", ",", "\<\"Another item\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"Another item\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"Item\"\>", ",", "\<\"Yet another item\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"Yet another item\"\>"}]}],
+         "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"Item\"\>", ",", "\<\"And there's more...\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", 
+          "\[Rule]", "\<\"And there's more...\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"\<\"H2\"\>", ",", "\<\"Paragraph modifiers\"\>"}], "]"}]},
@@ -459,10 +554,16 @@ from.\"\>"},
     {"\<\"LaTex is also supported:\"\>"},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"Item\"\>", ",", "\<\"inline\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"inline\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"LaTex\"\>", ",", 
+      RowBox[{"\<\"LaTeX\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
          RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Inline\"\>"}], ",", 
@@ -470,7 +571,7 @@ from.\"\>"},
         "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"LaTex\"\>", ",", 
+      RowBox[{"\<\"LaTeX\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
          RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Inline\"\>"}], ",", 
@@ -478,10 +579,16 @@ from.\"\>"},
         "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"Item\"\>", ",", "\<\"presented\"\>"}], "]"}]},
+      RowBox[{"\<\"Item\"\>", ",", 
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", "\<\"presented\"\>"}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"LaTex\"\>", ",", 
+      RowBox[{"\<\"LaTeX\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
          RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Display\"\>"}], ",", 
@@ -489,7 +596,7 @@ from.\"\>"},
         "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
-      RowBox[{"\<\"LaTex\"\>", ",", 
+      RowBox[{"\<\"LaTeX\"\>", ",", 
        RowBox[{"\[LeftAssociation]", 
         RowBox[{
          RowBox[{"\<\"Type\"\>", "\[Rule]", "\<\"Display\"\>"}], ",", 
@@ -502,45 +609,62 @@ from.\"\>"},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"\<\"Item\"\>", ",", 
-       RowBox[{"{", 
-        RowBox[{"\<\"A named link to\"\>", ",", 
-         RowBox[{"MarkdownElement", "[", 
-          RowBox[{
-          "Hyperlink", ",", "\<\"MarkItDown\"\>", 
-           ",", "\<\" http://www.markitdown.net/\"\>"}], "]"}], 
-         ",", "\<\". The easiest way to do these is to select what you want \
-to make a link and hit \"\>", ",", 
-         RowBox[{"MarkdownElement", "[", 
-          RowBox[{"\<\"InlineCode\"\>", ",", "\<\"Ctrl+L\"\>"}], "]"}], 
-         ",", "\<\".\"\>"}], "}"}]}], "]"}]},
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", 
+          RowBox[{"{", 
+           RowBox[{"\<\"A named link to\"\>", ",", 
+            RowBox[{"MarkdownElement", "[", 
+             RowBox[{"Hyperlink", ",", "\<\"MarkItDown\"\>", ",", 
+              RowBox[{"First", "[", 
+               RowBox[{"Private`ExtractMarkdownFootnoteURL", "[", 
+                RowBox[{"3", ",", "Private`footFile"}], "]"}], "]"}]}], "]"}],
+             ",", "\<\". The easiest way to do these is to select what you \
+want to make a link and hit \"\>", ",", 
+            RowBox[{"MarkdownElement", "[", 
+             RowBox[{"\<\"InlineCode\"\>", ",", "\<\"Ctrl+L\"\>"}], "]"}], 
+            ",", "\<\".\"\>"}], "}"}]}]}], "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"\<\"Item\"\>", ",", 
-       RowBox[{"{", 
-        RowBox[{"\<\"Another named link to\"\>", ",", 
-         RowBox[{"MarkdownElement", "[", 
-          RowBox[{"Hyperlink", ",", 
-           RowBox[{"\[LeftAssociation]", 
-            RowBox[{
-             RowBox[{"\<\"Label\"\>", "\[Rule]", "\<\"MarkItDown\"\>"}], ",", 
-             
-             
-             RowBox[{"\<\"Link\"\>", 
-              "\[Rule]", "\<\"http://www.markitdown.net/\"\>"}]}], 
-            "\[RightAssociation]"}]}], "]"}]}], "}"}]}], "]"}]},
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", 
+          RowBox[{"{", 
+           RowBox[{"\<\"Another named link to\"\>", ",", 
+            RowBox[{"MarkdownElement", "[", 
+             RowBox[{"Hyperlink", ",", 
+              RowBox[{"\[LeftAssociation]", 
+               RowBox[{
+                RowBox[{"\<\"Label\"\>", "\[Rule]", "\<\"MarkItDown\"\>"}], 
+                ",", 
+                
+                RowBox[{"\<\"Link\"\>", 
+                 "\[Rule]", "\<\"http://www.markitdown.net/\"\>"}]}], 
+               "\[RightAssociation]"}]}], "]"}]}], "}"}]}]}], 
+        "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"\<\"Item\"\>", ",", 
-       RowBox[{"{", 
-        RowBox[{"\<\"Sometimes you want the URL : \"\>", ",", 
-         RowBox[{"MarkdownElement", "[", 
-          RowBox[{"Hyperlink", ",", 
-           RowBox[{"\[LeftAssociation]", 
-            
-            RowBox[{"\<\"Link\"\>", 
-             "\[Rule]", "\<\"http://www.markitdown.net/\"\>"}], 
-            "\[RightAssociation]"}]}], "]"}], ",", "\<\".\"\>"}], "}"}]}], 
-      "]"}]},
+       RowBox[{"\[LeftAssociation]", 
+        RowBox[{
+         RowBox[{"\<\"IndentationLevel\"\>", "\[Rule]", "0"}], ",", 
+         RowBox[{"\<\"IndentationType\"\>", "\[Rule]", "None"}], ",", 
+         RowBox[{"\<\"Content\"\>", "\[Rule]", 
+          RowBox[{"{", 
+           RowBox[{"\<\"Sometimes you want the URL : \"\>", ",", 
+            RowBox[{"MarkdownElement", "[", 
+             RowBox[{"Hyperlink", ",", 
+              RowBox[{"\[LeftAssociation]", 
+               
+               RowBox[{"\<\"Link\"\>", 
+                "\[Rule]", "\<\"http://www.markitdown.net/\"\>"}], 
+               "\[RightAssociation]"}]}], "]"}], ",", "\<\".\"\>"}], 
+           "}"}]}]}], "\[RightAssociation]"}]}], "]"}]},
     {
      RowBox[{"MarkdownElement", "[", 
       RowBox[{"\<\"H2\"\>", ",", "\<\"Horizontal rule\"\>"}], "]"}]},
@@ -637,18 +761,59 @@ in rendering on other platforms.\"\>"}], "}"}]}
    GridBoxFrame->{"Columns" -> {{True}}, "Rows" -> {{True}}},
    GridBoxItemSize->{"Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}],
   "Column"]], "Output",
- CellChangeTimes->{3.817333317567844*^9, 3.817336356679491*^9, 
-  3.817337444405984*^9, 3.817337578187777*^9, 3.8173402117217703`*^9, 
-  3.8173405751737423`*^9, 3.817340858239677*^9, 3.817341038270464*^9, 
-  3.8173420586857357`*^9, 3.817342237287958*^9, 3.817342402189083*^9, 
-  3.8173426293798943`*^9, 3.817343093474086*^9, 3.8173437104903793`*^9, 
-  3.8173438533165483`*^9, 3.8173441277293653`*^9, 3.817344883363161*^9, 
-  3.817345144885262*^9, 3.8173454763293324`*^9, 3.817346050239132*^9, 
-  3.81734662850709*^9, 3.817346763411755*^9, 3.817389840621285*^9, 
-  3.8174164489123363`*^9},
- CellLabel->"Out[6]=",ExpressionUUID->"80983d5b-79cc-41b1-b3ea-8ac508483630"]
-}, Open  ]]
-}, Closed]],
+ CellChangeTimes->{
+  3.817333317567844*^9, 3.817336356679491*^9, 3.817337444405984*^9, 
+   3.817337578187777*^9, 3.8173402117217703`*^9, 3.8173405751737423`*^9, 
+   3.817340858239677*^9, 3.817341038270464*^9, 3.8173420586857357`*^9, 
+   3.817342237287958*^9, 3.817342402189083*^9, 3.8173426293798943`*^9, 
+   3.817343093474086*^9, 3.8173437104903793`*^9, 3.8173438533165483`*^9, 
+   3.8173441277293653`*^9, 3.817344883363161*^9, 3.817345144885262*^9, 
+   3.8173454763293324`*^9, 3.817346050239132*^9, 3.81734662850709*^9, 
+   3.817346763411755*^9, 3.817389840621285*^9, 3.8174164489123363`*^9, 
+   3.83978561192607*^9, {3.839786021507169*^9, 3.839786026115018*^9}, 
+   3.839786250526957*^9},
+ CellLabel->"Out[6]=",ExpressionUUID->"1851928c-a621-40b8-b5d9-bcd902336aef"]
+}, Open  ]],
+
+Cell[TextData[{
+ "Not sure why ",
+ Cell[BoxData[
+  FormBox[
+   StyleBox["ExtractMarkdownFootnote", "Input"], TraditionalForm]],
+  FormatType->TraditionalForm,ExpressionUUID->
+  "b0e0dc4e-b63e-4f55-a850-c838a32c651f"],
+ " doesn\[CloseCurlyQuote]t work \[DownArrow]\[DownArrow]\[DownArrow]"
+}], "Text",
+ CellChangeTimes->{{3.83978769828237*^9, 
+  3.8397877089314823`*^9}},ExpressionUUID->"fd11d7bb-32c7-4cc0-b0ef-\
+780fc0134e6d"],
+
+Cell[BoxData[
+ RowBox[{"MarkdownElement", "[", 
+  RowBox[{"\"\<Item\>\"", ",", 
+   RowBox[{"\[LeftAssociation]", 
+    RowBox[{
+     RowBox[{"\"\<IndentationLevel\>\"", "\[Rule]", "0"}], ",", 
+     RowBox[{"\"\<IndentationType\>\"", "\[Rule]", "None"}], ",", 
+     RowBox[{"\"\<Content\>\"", "\[Rule]", 
+      RowBox[{"{", 
+       RowBox[{"\"\<A named link to\>\"", ",", 
+        RowBox[{"MarkdownElement", "[", 
+         RowBox[{"Hyperlink", ",", "\"\<MarkItDown\>\"", ",", 
+          StyleBox[
+           RowBox[{"First", "[", 
+            RowBox[{"Private`ExtractMarkdownFootnoteURL", "[", 
+             RowBox[{"3", ",", "Private`footFile"}], "]"}], "]"}],
+           Background->RGBColor[1, 0.85, 0.85]]}], "]"}], ",", 
+        "\"\<. The easiest way to do these is to select what you want to make \
+a link and hit \>\"", ",", 
+        RowBox[{"MarkdownElement", "[", 
+         RowBox[{"\"\<InlineCode\>\"", ",", "\"\<Ctrl+L\>\""}], "]"}], ",", 
+        "\"\<.\>\""}], "}"}]}]}], "\[RightAssociation]"}]}], "]"}]], "Input",
+ CellChangeTimes->{3.839787558385516*^9, 
+  3.839787630053808*^9},ExpressionUUID->"b263aba7-97b0-4acf-882c-\
+d77f77a17c66"]
+}, Open  ]],
 
 Cell[CellGroupData[{
 
@@ -660,7 +825,7 @@ fc1c63394988"],
 Cell[CellGroupData[{
 
 Cell[BoxData["MarkdownParserTestReport"], "Input",
- CellLabel->"In[3]:=",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
+ CellLabel->"In[7]:=",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
 
 Cell[BoxData[
  InterpretationBox[
@@ -674,36 +839,34 @@ Cell[BoxData[
             PaneBox[
              ButtonBox[
               DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"]], 
-              ButtonFunction :> (Typeset`open$$ = True), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxOpener"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = True), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
                  Magnification])}]], 
-            GraphicsBox[{
-              InsetBox[
-               BoxData[
-                FormBox[
-                 PaneBox[
-                  DynamicBox[
-                   FEPrivate`FrontEndResource[
-                   "MUnitExpressions", "SuccessIcon"]], Alignment -> Center, 
-                  ImageSize -> 
-                  Dynamic[{
-                    Automatic, 
-                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification])}]], TraditionalForm]]]}, 
-             PlotRange -> {{0, 1}, {0, 1}}, Background -> GrayLevel[0.93], 
-             Axes -> False, AspectRatio -> 1, ImageSize -> 
+            GraphicsBox[
+             InsetBox[
+              PaneBox[
+               DynamicBox[
+                FEPrivate`FrontEndResource["MUnitExpressions", "SuccessIcon"],
+                 ImageSizeCache -> {16., {3., 9.}}], Alignment -> Center, 
+               ImageSize -> 
+               Dynamic[{
+                 Automatic, 
+                  3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                   Magnification])}]]], AspectRatio -> 1, Axes -> False, 
+             Background -> GrayLevel[0.93], Frame -> True, FrameStyle -> 
+             Directive[
+               Thickness[Tiny], 
+               GrayLevel[0.55]], FrameTicks -> None, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}], Frame -> True, FrameTicks -> None, 
-             FrameStyle -> Directive[
-               Thickness[Tiny], 
-               GrayLevel[0.55]]], 
+                 Magnification])}], PlotRange -> {{0, 1}, {0, 1}}], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Title: \"", "SummaryItemAnnotation"], 
@@ -718,53 +881,52 @@ Cell[BoxData[
                RowBox[{
                  TagBox["\"Tests run: \"", "SummaryItemAnnotation"], 
                  "\[InvisibleSpace]", 
-                 TagBox["28", "SummaryItem"]}]}}, 
-             GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, GridBoxItemSize -> {
-              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
+                 TagBox["28", "SummaryItem"]}]}}, AutoDelete -> False, 
+             BaseStyle -> {
               ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
+             GridBoxAlignment -> {
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}], True -> GridBox[{{
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}], True -> 
+        GridBox[{{
             PaneBox[
              ButtonBox[
               DynamicBox[
-               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"]], 
-              ButtonFunction :> (Typeset`open$$ = False), Appearance -> None, 
-              BaseStyle -> {}, Evaluator -> Automatic, Method -> 
-              "Preemptive"], Alignment -> {Center, Center}, ImageSize -> 
+               FEPrivate`FrontEndResource["FEBitmaps", "SummaryBoxCloser"], 
+               ImageSizeCache -> {11., {0., 11.}}], Appearance -> None, 
+              BaseStyle -> {}, ButtonFunction :> (Typeset`open$$ = False), 
+              Evaluator -> Automatic, Method -> "Preemptive"], 
+             Alignment -> {Center, Center}, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
                  Magnification])}]], 
-            GraphicsBox[{
-              InsetBox[
-               BoxData[
-                FormBox[
-                 PaneBox[
-                  DynamicBox[
-                   FEPrivate`FrontEndResource[
-                   "MUnitExpressions", "SuccessIcon"]], Alignment -> Center, 
-                  ImageSize -> 
-                  Dynamic[{
-                    Automatic, 
-                    3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                    Magnification])}]], TraditionalForm]]]}, 
-             PlotRange -> {{0, 1}, {0, 1}}, Background -> GrayLevel[0.93], 
-             Axes -> False, AspectRatio -> 1, ImageSize -> 
+            GraphicsBox[
+             InsetBox[
+              PaneBox[
+               DynamicBox[
+                FEPrivate`FrontEndResource["MUnitExpressions", "SuccessIcon"],
+                 ImageSizeCache -> {16., {3., 9.}}], Alignment -> Center, 
+               ImageSize -> 
+               Dynamic[{
+                 Automatic, 
+                  3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
+                   Magnification])}]]], AspectRatio -> 1, Axes -> False, 
+             Background -> GrayLevel[0.93], Frame -> True, FrameStyle -> 
+             Directive[
+               Thickness[Tiny], 
+               GrayLevel[0.55]], FrameTicks -> None, ImageSize -> 
              Dynamic[{
                Automatic, 
                 3.5 (CurrentValue["FontCapHeight"]/AbsoluteCurrentValue[
-                 Magnification])}], Frame -> True, FrameTicks -> None, 
-             FrameStyle -> Directive[
-               Thickness[Tiny], 
-               GrayLevel[0.55]]], 
+                 Magnification])}], PlotRange -> {{0, 1}, {0, 1}}], 
             GridBox[{{
                RowBox[{
                  TagBox["\"Title: \"", "SummaryItemAnnotation"], 
@@ -808,23 +970,22 @@ Cell[BoxData[
                  TagBox[
                   
                   TemplateBox[{
-                   "0.0107629999999999998`2.7352903067653798", "\"s\"", 
-                    "seconds", "\"Seconds\""}, "Quantity", SyntaxForm -> Mod],
-                   "SummaryItem"]}], "\[SpanFromLeft]"}}, 
+                   "0.0036930000000000002`2.2707362741407513", "\"s\"", 
+                    "seconds", "\"Seconds\""}, "Quantity"], "SummaryItem"]}], 
+               "\[SpanFromLeft]"}}, AutoDelete -> False, 
+             BaseStyle -> {
+              ShowStringCharacters -> False, NumberMarks -> False, 
+               PrintPrecision -> 3, ShowSyntaxStyles -> False}, 
              GridBoxAlignment -> {
-              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
-             False, 
+              "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, 
              GridBoxItemSize -> {
               "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-             GridBoxSpacings -> {"Columns" -> {{2}}, "Rows" -> {{Automatic}}},
-              BaseStyle -> {
-              ShowStringCharacters -> False, NumberMarks -> False, 
-               PrintPrecision -> 3, ShowSyntaxStyles -> False}]}}, 
+             GridBoxSpacings -> {
+              "Columns" -> {{2}}, "Rows" -> {{Automatic}}}]}}, AutoDelete -> 
+          False, BaselinePosition -> {1, 1}, 
           GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
-          AutoDelete -> False, 
           GridBoxItemSize -> {
-           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
-          BaselinePosition -> {1, 1}]}, 
+           "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}]}, 
        Dynamic[Typeset`open$$], ImageSize -> Automatic]},
      "SummaryPanel"],
     DynamicModuleValues:>{}], "]"}],
@@ -840,9 +1001,9 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement["H1", "A Title"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000589`2.9206302926190952, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0005850000000000577, "Seconds"], "MemoryUsed" -> 
-         Quantity[29640, "Bytes"]]], 2 -> TestResultObject[
+         Quantity[0.000222`2.496867972282628, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00022300000000008424`, "Seconds"], "MemoryUsed" -> 
+         Quantity[30400, "Bytes"]]], 2 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 2, "TestID" -> "H2Test", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -852,9 +1013,9 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement["H2", "A Subtitle"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.00032`2.6556649761518996, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00031800000000048456`, "Seconds"], "MemoryUsed" -> 
-         Quantity[472, "Bytes"]]], 3 -> TestResultObject[
+         Quantity[0.000111`2.195837976618649, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010899999999969268`, "Seconds"], "MemoryUsed" -> 
+         Quantity[584, "Bytes"]]], 3 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 3, "TestID" -> "H3Test", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -864,8 +1025,8 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement["H3", "A Chapter"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000301`2.6290814934258373, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00029699999999976967`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000109`2.1879414957726175, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010799999999999699`, "Seconds"], "MemoryUsed" -> 
          Quantity[192, "Bytes"]]], 4 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 4, "TestID" -> "H4Test", 
@@ -876,8 +1037,8 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement["H4", "A Section"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000297`2.623271447149206, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0002949999999999342, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000103`2.1633522225371657, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010300000000018628`, "Seconds"], "MemoryUsed" -> 
          Quantity[192, "Bytes"]]], 5 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 5, "TestID" -> "H5Test", 
@@ -888,8 +1049,8 @@ Cell[BoxData[
          "ActualOutput" -> HoldForm[
            MarkdownParse`MarkdownElement["H5", "A Subsection"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000301`2.6290814934258373, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0002990000000000492, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000107`2.1798987755172035, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010699999999941312`, "Seconds"], "MemoryUsed" -> 
          Quantity[192, "Bytes"]]], 6 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 6, "TestID" -> "H6Test", 
@@ -900,8 +1061,8 @@ Cell[BoxData[
          "ActualOutput" -> HoldForm[
            MarkdownParse`MarkdownElement["H6", "A Subsubsection"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000414`2.7675153389528933, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00039999999999995595`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000105`2.171704296901932, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010500000000046583`, "Seconds"], "MemoryUsed" -> 
          Quantity[192, "Bytes"]]], 7 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 7, "TestID" -> "HNTest", 
@@ -910,8 +1071,8 @@ Cell[BoxData[
          "ExpectedOutput" -> HoldForm["####### A Paragraph"], "ActualOutput" -> 
          HoldForm["####### A Paragraph"], "ExpectedMessages" -> {}, 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000111`2.1958379766186513, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00011100000000041632`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000036`1.706817498599281, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00003500000000000725, "Seconds"], "MemoryUsed" -> 
          Quantity[112, "Bytes"]]], 8 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 8, "TestID" -> "ItalicTest1", 
@@ -922,8 +1083,8 @@ Cell[BoxData[
          HoldForm[
            MarkdownParse`MarkdownElement[Italic, "test"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000293`2.6173826181861037, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0002900000000001235, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000101`2.154836371614637, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00009900000000007125, "Seconds"], "MemoryUsed" -> 
          Quantity[152, "Bytes"]]], 9 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 9, "TestID" -> "ItalicTest2", 
@@ -934,8 +1095,8 @@ Cell[BoxData[
          HoldForm[{"this is a ", 
             MarkdownParse`MarkdownElement[Italic, "test"]}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000244`2.5379048241707234, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0002410000000003798, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000085`2.079933923546286, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00008400000000019503, "Seconds"], "MemoryUsed" -> 
          Quantity[248, "Bytes"]]], 10 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 10, "TestID" -> "ItalicTest3", 
@@ -947,8 +1108,8 @@ Cell[BoxData[
             MarkdownParse`MarkdownElement[Italic, "different kind"], 
             " of test"}], "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
          "AbsoluteTimeUsed" -> 
-         Quantity[0.000291`2.614407986817901, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00028799999999984394`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000106`2.175820863096762, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00010600000000016152`, "Seconds"], "MemoryUsed" -> 
          Quantity[296, "Bytes"]]], 11 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 11, "TestID" -> "ItalicTest4", 
@@ -965,9 +1126,9 @@ Cell[BoxData[
             MarkdownParse`MarkdownElement[Bold, "different"], " ", 
             MarkdownParse`MarkdownElement[Italic, "kind"], " of test"}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.00054`2.882908757654963, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0005359999999998699, "Seconds"], "MemoryUsed" -> 
-         Quantity[720, "Bytes"]]], 12 -> TestResultObject[
+         Quantity[0.000197`2.4449812239935844, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00019700000000000273`, "Seconds"], "MemoryUsed" -> 
+         Quantity[576, "Bytes"]]], 12 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 12, "TestID" -> "ItalicTest5", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -979,9 +1140,9 @@ Cell[BoxData[
             MarkdownParse`MarkdownElement[Italic, 
              MarkdownParse`MarkdownElement[Bold, "mixed bag"]], " test"}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000566`2.903331429020265, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0005639999999993428, "Seconds"], "MemoryUsed" -> 
-         Quantity[416, "Bytes"]]], 13 -> TestResultObject[
+         Quantity[0.000203`2.458011035745205, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00020199999999981344`, "Seconds"], "MemoryUsed" -> 
+         Quantity[496, "Bytes"]]], 13 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 13, "TestID" -> "BlockQuoteTest1",
           "Outcome" -> "Success", "Input" -> HoldForm[
@@ -993,9 +1154,10 @@ Cell[BoxData[
            MarkdownParse`MarkdownElement["BlockQuote", {"a ", 
              MarkdownParse`MarkdownElement[Italic, "block quote"], " test"}]],
           "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> Quantity[0.00053`2.874790867432783, "Seconds"],
-          "CPUTimeUsed" -> Quantity[0.0005290000000002237, "Seconds"], 
-         "MemoryUsed" -> Quantity[344, "Bytes"]]], 14 -> TestResultObject[
+         "AbsoluteTimeUsed" -> 
+         Quantity[0.000199`2.449368074241699, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00019999999999997797`, "Seconds"], "MemoryUsed" -> 
+         Quantity[344, "Bytes"]]], 14 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 14, "TestID" -> "TableTest1", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1030,9 +1192,9 @@ Cell[BoxData[
                MarkdownParse`MarkdownElement[
                "TableRow", {"1 ", " 2 ", " 3"}]}}]}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.00279`3.5961192011055916, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00264700000000051, "Seconds"], "MemoryUsed" -> 
-         Quantity[30536, "Bytes"]]], 15 -> TestResultObject[
+         Quantity[0.000947`3.126864976835263, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.0009429999999999161, "Seconds"], "MemoryUsed" -> 
+         Quantity[30224, "Bytes"]]], 15 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 15, "TestID" -> "CodeBlockTest1", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1049,9 +1211,9 @@ Cell[BoxData[
              "Language" -> "Mathematica", "Body" -> "f[x]:=2;\nf[y]:=3"]], 
             "\n"}], "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
          "AbsoluteTimeUsed" -> 
-         Quantity[0.000274`2.588265560652382, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0002699999999995484, "Seconds"], "MemoryUsed" -> 
-         Quantity[768, "Bytes"]]], 16 -> TestResultObject[
+         Quantity[0.000074`2.0197467175629678, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00007400000000012952, "Seconds"], "MemoryUsed" -> 
+         Quantity[632, "Bytes"]]], 16 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 16, "TestID" -> "CodeBlockTest2", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1066,9 +1228,9 @@ Cell[BoxData[
              Association[
              "Language" -> "None", "Body" -> "f[x]:=2;\nf[y]:=3"]], "\n"}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000215`2.482953457747599, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0002140000000001585, "Seconds"], "MemoryUsed" -> 
-         Quantity[728, "Bytes"]]], 17 -> TestResultObject[
+         Quantity[0.000069`1.9893640885692467, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.0000690000000003188, "Seconds"], "MemoryUsed" -> 
+         Quantity[592, "Bytes"]]], 17 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 17, "TestID" -> "CodeBlockTest3", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1086,9 +1248,9 @@ Cell[BoxData[
              "Language" -> "None", "Body" -> 
               "A generic code block\n    With some text\n"]]}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000135`2.280848766327, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00013199999999979894`, "Seconds"], "MemoryUsed" -> 
-         Quantity[648, "Bytes"]]], 18 -> TestResultObject[
+         Quantity[0.000045`1.8037275116073337, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000042999999999793204`, "Seconds"], "MemoryUsed" -> 
+         Quantity[576, "Bytes"]]], 18 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 18, "TestID" -> "InlineCodeTest1",
           "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1098,8 +1260,8 @@ Cell[BoxData[
          "ActualOutput" -> HoldForm[
            MarkdownParse`MarkdownElement["InlineCode", "inline code"]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000172`2.386043444739543, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.000172000000000061, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000056`1.898703024838192, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00005599999999983396, "Seconds"], "MemoryUsed" -> 
          Quantity[160, "Bytes"]]], 19 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 19, "TestID" -> "InlineCodeTest2",
@@ -1114,8 +1276,8 @@ Cell[BoxData[
             MarkdownParse`MarkdownElement["InlineCode", "code block"], 
             " formatting anywhere"}], "ExpectedMessages" -> {}, 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000213`2.4788946012707314, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00021199999999987895`, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000075`2.0255762612236934, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00007599999999996498, "Seconds"], "MemoryUsed" -> 
          Quantity[312, "Bytes"]]], 20 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 20, "TestID" -> "InlineCodeTest3",
@@ -1131,66 +1293,66 @@ Cell[BoxData[
              MarkdownParse`MarkdownElement["InlineCode", "inline code"], 
              " inserted"}]], "ExpectedMessages" -> {}, "ActualMessages" -> {},
           "AbsoluteTimeUsed" -> 
-         Quantity[0.000617`2.9408001618652357, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0006119999999998349, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000228`2.5084498448324477, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.0002300000000001745, "Seconds"], "MemoryUsed" -> 
          Quantity[456, "Bytes"]]], 21 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 21, "TestID" -> 
          "InlineLaTeXTest1", "Outcome" -> "Success", "Input" -> HoldForm[
            FixedPoint[Private`MarkdownParser, "\(a^2 + b^2 = c^2\)"]], 
          "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTex", 
+           MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]], 
          "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTex", 
+           MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000126`2.2508855429495567, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.000124000000000013, "Seconds"], "MemoryUsed" -> 
-         Quantity[520, "Bytes"]]], 22 -> TestResultObject[
+         Quantity[0.000042`1.7737642882298899, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004400000000037707, "Seconds"], "MemoryUsed" -> 
+         Quantity[456, "Bytes"]]], 22 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 22, "TestID" -> 
          "InlineLaTeXTest2", "Outcome" -> "Success", "Input" -> HoldForm[
            FixedPoint[Private`MarkdownParser, "$ a^2 + b^2 = c^2 $"]], 
          "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTex", 
+           MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]], 
          "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTex", 
+           MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000158`2.3491720847864164, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0001550000000003493, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.000041`1.7632988545517252, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004099999999995774, "Seconds"], "MemoryUsed" -> 
          Quantity[464, "Bytes"]]], 23 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 23, "TestID" -> 
          "DisplayLaTeXTest1", "Outcome" -> "Success", "Input" -> HoldForm[
            FixedPoint[Private`MarkdownParser, "\\[ a^n + b^n = c^n \\]"]], 
          "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTex", 
+           MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]], 
          "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTex", 
+           MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000136`2.284053906202211, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0001340000000000785, "Seconds"], "MemoryUsed" -> 
+         Quantity[0.00004`1.7525749891599518, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00004000000000026205, "Seconds"], "MemoryUsed" -> 
          Quantity[456, "Bytes"]]], 24 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 24, "TestID" -> 
          "DisplayLaTeXTest2", "Outcome" -> "Success", "Input" -> HoldForm[
            FixedPoint[Private`MarkdownParser, "$$ a^2 + b^2 = c^2 $$"]], 
          "ExpectedOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTex", 
+           MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]],
           "ActualOutput" -> HoldForm[
-           MarkdownParse`MarkdownElement["LaTex", 
+           MarkdownParse`MarkdownElement["LaTeX", 
             Association["Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]],
           "ExpectedMessages" -> {}, "ActualMessages" -> {}, 
          "AbsoluteTimeUsed" -> 
-         Quantity[0.000134`2.2776197961968014, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00013200000000024303`, "Seconds"], "MemoryUsed" -> 
-         Quantity[528, "Bytes"]]], 25 -> TestResultObject[
+         Quantity[0.000039`1.7415796048584888, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000036999999999842714`, "Seconds"], "MemoryUsed" -> 
+         Quantity[464, "Bytes"]]], 25 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 25, "TestID" -> "LinkTest1", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1205,9 +1367,9 @@ Cell[BoxData[
             Association[
             "Label" -> "click here", "Link" -> "www.google.com"]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000281`2.599221317737074, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.0002789999999999182, "Seconds"], "MemoryUsed" -> 
-         Quantity[568, "Bytes"]]], 26 -> TestResultObject[
+         Quantity[0.000091`2.1095563901530854, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00008999999999925734, "Seconds"], "MemoryUsed" -> 
+         Quantity[496, "Bytes"]]], 26 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 26, "TestID" -> "LinkTest2", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1219,9 +1381,9 @@ Cell[BoxData[
            MarkdownParse`MarkdownElement[Hyperlink, 
             Association["Link" -> "www.google.com"]]], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000125`2.2474250108400504, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00012299999999942912`, "Seconds"], "MemoryUsed" -> 
-         Quantity[440, "Bytes"]]], 27 -> TestResultObject[
+         Quantity[0.00004`1.752574989159956, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00003900000000012227, "Seconds"], "MemoryUsed" -> 
+         Quantity[368, "Bytes"]]], 27 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 27, "TestID" -> "ImageLinkTest1", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1246,9 +1408,9 @@ format&fit=crop&w=564&q=80"]]], "ActualOutput" -> HoldForm[
 ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
 format&fit=crop&w=564&q=80"]]], "ExpectedMessages" -> {}, 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000164`2.3653588458796917, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00016199999999999548`, "Seconds"], "MemoryUsed" -> 
-         Quantity[680, "Bytes"]]], 28 -> TestResultObject[
+         Quantity[0.000062`1.9429066873302476, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.000058000000000113516`, "Seconds"], "MemoryUsed" -> 
+         Quantity[752, "Bytes"]]], 28 -> TestResultObject[
         Association[
         "TestClass" -> None, "TestIndex" -> 28, "TestID" -> "FoonoteTest1", 
          "Outcome" -> "Success", "Input" -> HoldForm[
@@ -1268,15 +1430,15 @@ footnote][2]"]], "ExpectedOutput" -> HoldForm[{
             MarkdownParse`MarkdownElement[Hyperlink, "the second footnote", 
              MarkdownParse`MarkdownElement["FootnoteReference", {2}]]}], 
          "ExpectedMessages" -> {}, "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         Quantity[0.000426`2.7799245969347126, "Seconds"], "CPUTimeUsed" -> 
-         Quantity[0.00042199999999992244`, "Seconds"], "MemoryUsed" -> 
-         Quantity[752, "Bytes"]]]], 
+         Quantity[0.00016`2.3546349804879183, "Seconds"], "CPUTimeUsed" -> 
+         Quantity[0.00015999999999971593`, "Seconds"], "MemoryUsed" -> 
+         Quantity[608, "Bytes"]]]], 
     "TestsSucceededIndices" -> {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
       15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28}, 
     "TestsFailedIndices" -> {}, "TestsFailedWrongResultsIndices" -> {}, 
     "TestsFailedWithMessagesIndices" -> {}, 
     "TestsFailedWithErrorsIndices" -> {}, "TimeElapsed" -> 
-    Quantity[0.0107629999999999998`2.7352903067653798, "Seconds"], 
+    Quantity[0.0036930000000000002`2.2707362741407513, "Seconds"], 
     "TestsSucceededCount" -> 28, "TestsFailedCount" -> 0, 
     "TestsFailedWrongResultsCount" -> 0, "TestsFailedWithMessagesCount" -> 0, 
     "TestsFailedWithErrorsCount" -> 0, "Aborted" -> False]],
@@ -1298,10 +1460,11 @@ footnote][2]"]], "ExpectedOutput" -> HoldForm[{
    3.817413163046644*^9, 3.817413505565199*^9, 3.817413647393132*^9, 
    3.817413740261161*^9, 3.817413987525134*^9, 3.817414184435028*^9, 
    3.817414459927204*^9, 3.8174145345787983`*^9, 3.8174157551387587`*^9, 
-   3.8174159839662447`*^9, 3.817416073446569*^9, 3.8174164180390863`*^9},
- CellLabel->"Out[3]=",ExpressionUUID->"0d6ee9b0-1835-4dd4-b358-105875962f77"]
+   3.8174159839662447`*^9, 3.817416073446569*^9, 3.8174164180390863`*^9, 
+   3.839786422508462*^9},
+ CellLabel->"Out[7]=",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
 }, Open  ]]
-}, Closed]],
+}, Open  ]],
 
 Cell[CellGroupData[{
 
@@ -1322,107 +1485,129 @@ Cell[BoxData[
  CellChangeTimes->{{3.817338483648481*^9, 3.817338514376762*^9}, {
   3.817338549203024*^9, 3.8173385637218513`*^9}, {3.8173386190942373`*^9, 
   3.817338641963245*^9}, {3.8173386747102633`*^9, 3.817338735575045*^9}},
- CellLabel->"In[7]:=",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
+ CellLabel->"In[12]:=",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
 
 Cell[BoxData[
  GraphicsBox[
   NamespaceBox["NetworkGraphics",
    DynamicModuleBox[{Typeset`graph = HoldComplete[
-     Graph[CompressedData["
-1:eJwl1FV4EAQUBeA1ISBSSjO6EWmQlu4R0jFQeqMR6RQVJVUalG7p7gZB6Ubp
-Lunm38fDf+7DeT43PDI6IiowICAgloi5QQQTQihhMR2xiUNcPiAe8UnAhyTk
-IxKRmCQkJRkf8wnJSUFKUpGaNKQlHeGkJwMZyURmspCVbGQnBznJRW7y8Cl5
-+Yx85KcABSlEYYpQlGJ8TnFKUJJSlKYMZfmCcpSnAhWpRGWqUJVqVKcGNalF
-BLWpQ13q8SX1aUBDGtGYJjSlGc1pQSQtacVXfE1r2tCWdrSnAx2JIppOdKYL
-XelGd3rQk2/oxbf0pg996Ud/BjCQQQxmCEMZxncM53t+4EdG8BM/M5JRjGYM
-YxnHL/zKb4xnAhOZxGSmMJVpTOd3/mAGM5nFbOYwl3nMZwELWcRilvAnS1nG
-clawklWsZg1rWcd6NrCRTWxmC1vZxnZ2sJNd7GYPe9nHfv7iAAf5m384xGGO
-cJRjHOcEJznFac5wlnOc51/+4wIXucRlrnCVa1znBje5xW3ucJd73OcB//OQ
-RzzmCU95xnNe8JJXvOYNb4kZfyBBBBNCKGGB73/DO9oHgWA=
-      "], {
+     Graph[{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+       20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+       38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+       56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+       74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
+       92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
+       108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 
+      122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 
+      136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 
+      150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 
+      164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 
+      178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 
+      192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 
+      206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 
+      220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 
+      234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244}, {
       Null, CompressedData["
-1:eJwt0HV0lmUAxuFvwEZKg4gSoxsRQemU7u6YIqKEdHcoId3d3d1dCgpIKN0o
-qXTHxq4/fuc6z/0+7/vtLDSsTbXWUQKBQEhQIBBhOO+NKCqj2YMVwuiKwZiM
-5Xls78XRB4xrj6f4TGBPyERKzCRKyg/tyfiRkvNj+ye+l0IpmUqpGao0TKt0
-TG/P4P2MvptJmZnFnlXZmN2eQzn5qXI5f+Zebn3OPMrr/IV7Xyof86uAc0H3
-Cqkwi6ioczH3iqsES+orllJplmFZz8v5TnlVYEV7JVVmFXtVVWN1ew3VZC17
-bdVhXXs91WcDe0M1YmN7EzVlmP1rfcNm+pbN7d+530Lf8wd7S7Via3sb/ci2
-9nZsrw7sqE7srC7sau/G7urBnr7bS73ZR33ZT/05wHsDOYg/6WcOtg/hUA3j
-L/bhGsGR9lEazTH2sRrH8fYJmshJ9smawqn2aZrOGfaZnKXZnKO5nKf5XMCF
-ni/iYi3hUvsyv7NcK7hSq7haa7jWe+u0nhu0kZu0mVvsW72/Tdu5w76Tu7Tb
-eY/2cp99vw7woH7Vbzykw/ydf7h/REd5TH/quPMJnXQ+pb9852+d1hme1Tmd
-1wVetF9y77Ku8Kqu8br9hvv/6F/e1C3e9nfd0V3e03/8n/f9fx/oIR/ZH/OJ
-nvKZ/ble8KX9lV7zjd4y4lKEQUGRz6MwalBk0RjMEM+jh/sOQ0/raw==
+1:eJwB9wEI/iFib1JiAgAAAPMAAAACAAAAAQICAwIEAQUFBgUHBwgHCQcKBQsB
+DAwNDA4BDw8QDxEBEgETExQTFRUWFRcTGBMZGRoZGxMcAR0dHh0fHyAfISEi
+ISMjJCMlISYdJwEoKCkoKgErKywrLQEuLi8uMDAxLjIBMzM0MzU1NjM3ATg4
+OTg6Ojs4PAE9PT49Pz9APUEBQkJDQkRERURGRkdGSEZJREoBS0tMS00BTk5P
+TlABUVFSUVMBVFRVVFYBV1dYV1kBWlpbWlwBXV1eXV8BYGBhYGIBY2NkY2Vl
+ZmVnY2gBaWlqaWsBbGxtbG4Bb29wb3EBcgFzc3RzdXV2dXd3eHd5dXp1e3t8
+e30Bfn5/foCAgYCCgoOChAGFAYYBh4eIh4kBigGLi4yLjQGOjo+OkAGRkZKR
+kwGUlJWUlgGXl5iXmQGampuanAGdnZ6dnwGgAaGhoqGjAaSkpaSmAaenqKep
+Aaqqq6qsAa0Brq6vAbCwsbCyAbOztLO1tba2t7a4uLm4uri7tby8vby+vr+/
+wL7BwcK+w8PEtcXFxsbHxsjIycnKysvKzMnNyM7Oz87Q0NHQ0s7TyNTU1dTW
+1tfW2MXZ2drZ29vc293b3gHf3+Df4QHiAePj5OPlAebm5+boAenp6unr6+zr
+7evu6e/p8PDx8PLw8+n0vjrSlg==
        "]}, {
       AnnotationRules -> {
-        188 -> {"Subexpression" -> HoldForm["."]}, 
-         226 -> {"Subexpression" -> HoldForm[" "]}, 
-         138 -> {"Subexpression" -> HoldForm["LaTex is also supported:"]}, 
-         167 -> {"Subexpression" -> HoldForm["MarkItDown"]}, 
-         83 -> {"Subexpression" -> HoldForm["Another item"]}, 
-         234 -> {"Subexpression" -> HoldForm[Bold]}, 
-         244 -> {"Subexpression" -> HoldForm["Images"]}, 
-         178 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Hyperlink, 
-              Association[
-              "Label" -> "MarkItDown", "Link" -> 
-               "http://www.markitdown.net/"]]]}, 
-         105 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H3", "Quote"]]}, 
-         112 -> {"Subexpression" -> HoldForm["H2"]}, 
-         185 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Hyperlink, 
-              Association["Link" -> "http://www.markitdown.net/"]]]}, 
-         42 -> {"Subexpression" -> HoldForm["Lists"]}, 
-         41 -> {"Subexpression" -> HoldForm["H2"]}, 
-         28 -> {"Subexpression" -> HoldForm[" formatting."]}, 
-         208 -> {"Subexpression" -> HoldForm["TableAlignment"]}, 
-         207 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             "TableAlignment", {{Center}, {Center}, {Center}}]]}, 
-         224 -> {"Subexpression" -> HoldForm[" "]}, 
-         11 -> {"Subexpression" -> HoldForm[" is capable of doing."]}, 
-         201 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             "TableHeader", {"Markdown ", " Less ", " Pretty"}]]}, 
-         95 -> {"Subexpression" -> HoldForm["Code block"]}, 
+        79 -> {"Subexpression" -> HoldForm["Item"]}, 
+         24 -> {"Subexpression" -> HoldForm[" and "]}, 
+         101 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["InlineCode", "inline code"]]}, 
+         131 -> {"Subexpression" -> HoldForm["InlineCode"]}, 
+         166 -> {"Subexpression" -> HoldForm[
+             Association[
+             "IndentationLevel" -> 0, "IndentationType" -> None, 
+              "Content" -> {"Another named link to", 
+                MarkdownParse`MarkdownElement[Hyperlink, 
+                 Association[
+                 "Label" -> "MarkItDown", "Link" -> 
+                  "http://www.markitdown.net/"]]}]]}, 
          73 -> {"Subexpression" -> 
            HoldForm[
             " http://www.fileformat.info/info/unicode/char/2163/index.htm"]}, 
-         220 -> {"Subexpression" -> HoldForm[{
-              MarkdownParse`MarkdownElement[Italic, "Still"], " "}]}, 
-         160 -> {"Subexpression" -> 
-           HoldForm["Add hyperlinks in the following ways:"]}, 
-         17 -> {"Subexpression" -> HoldForm["Basic formatting"]}, 
-         171 -> {"Subexpression" -> HoldForm["InlineCode"]}, 
-         84 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["Item", "Yet another item"]]}, 
-         232 -> {"Subexpression" -> HoldForm[" "]}, 
-         250 -> {"Subexpression" -> HoldForm["H2"]}, 
-         190 -> {"Subexpression" -> HoldForm["H2"]}, 
-         258 -> {"Subexpression" -> HoldForm[" and"]}, 
-         48 -> {"Subexpression" -> HoldForm[{1}]}, 
-         64 -> {"Subexpression" -> HoldForm[4]}, 
-         120 -> {"Subexpression" -> HoldForm[Italic]}, 
-         210 -> {"Subexpression" -> HoldForm[{Center}]}, 
-         156 -> {"Subexpression" -> HoldForm[
+         175 -> {"Subexpression" -> HoldForm["HorizontalLine"]}, 
+         26 -> {"Subexpression" -> HoldForm[Bold]}, 
+         130 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["InlineCode", "inline code"]]}, 
+         123 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[Bold, "formatting"]]}, 
+         215 -> {"Subexpression" -> HoldForm[Bold]}, 
+         62 -> {"Subexpression" -> HoldForm["ItemNumbered"]}, 
+         172 -> {"Subexpression" -> HoldForm["Horizontal rule"]}, 
+         234 -> {"Subexpression" -> 
+           HoldForm[
+            "There's actually a lot more to Markdown than this. See the \
+official"]}, 47 -> {"Subexpression" -> HoldForm["ItemNumbered"]}, 
+         29 -> {"Subexpression" -> 
+           HoldForm[{"Lines can have nested styling as well, like ", 
+              MarkdownParse`MarkdownElement[Italic, {"a ", 
+                MarkdownParse`MarkdownElement[Bold, "bold"], 
+                " in an italic"}], "."}]}, 
+         225 -> {"Subexpression" -> HoldForm["Images"]}, 
+         119 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[Italic, "can"]]}, 
+         183 -> {"Subexpression" -> HoldForm["TableHeader"]}, 
+         116 -> {"Subexpression" -> HoldForm["H3"]}, 
+         41 -> {"Subexpression" -> HoldForm["H2"]}, 
+         12 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[
+             Italic, "Note: Feel free to play with this page. Unlike regular \
+notes, this doesn't automatically save itself."]]}, 
+         169 -> {"Subexpression" -> HoldForm[
              Association[
-             "Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]}, 
-         21 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Italic, "italic"]]}, 
+             "IndentationLevel" -> 0, "IndentationType" -> None, 
+              "Content" -> {"Sometimes you want the URL : ", 
+                MarkdownParse`MarkdownElement[Hyperlink, 
+                 Association["Link" -> "http://www.markitdown.net/"]], 
+                "."}]]}, 228 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
+         102 -> {"Subexpression" -> HoldForm["InlineCode"]}, 
+         176 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H2", "Tables"]]}, 
+         2 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H1", "An exhibit of Markdown"]]}, 
+         200 -> {"Subexpression" -> HoldForm[{{
+               MarkdownParse`MarkdownElement[Italic, "Still"], " "}, {" ", 
+               MarkdownParse`MarkdownElement["InlineCode", "renders"], " "}, {
+              " ", 
+               MarkdownParse`MarkdownElement[Bold, "nicely"]}}]}, 
+         109 -> {"Subexpression" -> HoldForm["BlockQuote"]}, 
+         243 -> {"Subexpression" -> 
+           HoldForm[" http://daringfireball.net/projects/markdown/syntax"]}, 
+         211 -> {"Subexpression" -> HoldForm[" "]}, 
+         212 -> {"Subexpression" -> HoldForm[{" ", 
+              MarkdownParse`MarkdownElement[Bold, "nicely"]}]}, 
+         90 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H2", "Paragraph modifiers"]]}, 
+         149 -> {"Subexpression" -> HoldForm["Item"]}, 
          153 -> {"Subexpression" -> HoldForm[
              Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]}, 
-         68 -> {"Subexpression" -> 
-           HoldForm[{"Note: the fourth item uses the Unicode character for", 
-              MarkdownParse`MarkdownElement[
-              Hyperlink, "Roman numeral four", 
-               " http://www.fileformat.info/info/unicode/char/2163/index.htm"]\
-, "."}]}, 176 -> {"Subexpression" -> HoldForm[{"Another named link to", 
-              MarkdownParse`MarkdownElement[Hyperlink, 
-               Association[
-               "Label" -> "MarkItDown", "Link" -> 
-                "http://www.markitdown.net/"]]}]}, 
-         230 -> {"Subexpression" -> HoldForm[" "]}, 
+         244 -> {"Subexpression" -> 
+           HoldForm[
+            " for more information. Be aware that this document is not using \
+the official implementation, and there may be subtle differences in rendering \
+on other platforms."]}, 83 -> {"Subexpression" -> HoldForm[
+             Association[
+             "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+              "Another item"]]}, 49 -> {"Subexpression" -> HoldForm[1]}, 
+         221 -> {"Subexpression" -> HoldForm[" 2 "]}, 
+         42 -> {"Subexpression" -> HoldForm["Lists"]}, 
+         57 -> {"Subexpression" -> HoldForm["ItemNumbered"]}, 
+         30 -> {"Subexpression" -> 
+           HoldForm["Lines can have nested styling as well, like "]}, 
+         92 -> {"Subexpression" -> HoldForm["Paragraph modifiers"]}, 
          1 -> {"Subexpression" -> HoldForm[{
               MarkdownParse`MarkdownElement["H1", "An exhibit of Markdown"], {
               "This note demonstrates some of what", 
@@ -1459,10 +1644,22 @@ should become anything else.", {
                  " http://www.fileformat.info/info/unicode/char/2163/index.\
 htm"], "."}], 
               MarkdownParse`MarkdownElement["H3", "Unordered list"], 
-              MarkdownParse`MarkdownElement["Item", "An item"], 
-              MarkdownParse`MarkdownElement["Item", "Another item"], 
-              MarkdownParse`MarkdownElement["Item", "Yet another item"], 
-              MarkdownParse`MarkdownElement["Item", "And there's more..."], 
+              MarkdownParse`MarkdownElement["Item", 
+               Association[
+               "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+                "An item"]], 
+              MarkdownParse`MarkdownElement["Item", 
+               Association[
+               "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+                "Another item"]], 
+              MarkdownParse`MarkdownElement["Item", 
+               Association[
+               "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+                "Yet another item"]], 
+              MarkdownParse`MarkdownElement["Item", 
+               Association[
+               "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+                "And there's more..."]], 
               MarkdownParse`MarkdownElement["H2", "Paragraph modifiers"], 
               MarkdownParse`MarkdownElement["H3", "Code block"], 
               MarkdownParse`MarkdownElement["CodeBlock", 
@@ -1497,39 +1694,53 @@ noticeably larger and more important, there aren't any other sizes to choose \
 from.", 
               MarkdownParse`MarkdownElement["H2", "LaTex"], 
               "LaTex is also supported:", 
-              MarkdownParse`MarkdownElement["Item", "inline"], 
-              MarkdownParse`MarkdownElement["LaTex", 
+              MarkdownParse`MarkdownElement["Item", 
+               Association[
+               "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+                "inline"]], 
+              MarkdownParse`MarkdownElement["LaTeX", 
                Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]], 
               
-              MarkdownParse`MarkdownElement["LaTex", 
+              MarkdownParse`MarkdownElement["LaTeX", 
                Association[
                "Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]], 
-              MarkdownParse`MarkdownElement["Item", "presented"], 
-              MarkdownParse`MarkdownElement["LaTex", 
+              MarkdownParse`MarkdownElement["Item", 
+               Association[
+               "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+                "presented"]], 
+              MarkdownParse`MarkdownElement["LaTeX", 
                Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]], 
-              MarkdownParse`MarkdownElement["LaTex", 
+              MarkdownParse`MarkdownElement["LaTeX", 
                Association[
                "Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]], 
               MarkdownParse`MarkdownElement["H2", "URLs"], 
               "Add hyperlinks in the following ways:", 
-              MarkdownParse`MarkdownElement["Item", {"A named link to", 
-                MarkdownParse`MarkdownElement[
-                Hyperlink, "MarkItDown", " http://www.markitdown.net/"], 
-                ". The easiest way to do these is to select what you want to \
-make a link and hit ", 
-                MarkdownParse`MarkdownElement["InlineCode", "Ctrl+L"], "."}], 
-              
-              MarkdownParse`MarkdownElement[
-              "Item", {"Another named link to", 
-                MarkdownParse`MarkdownElement[Hyperlink, 
-                 Association[
-                 "Label" -> "MarkItDown", "Link" -> 
-                  "http://www.markitdown.net/"]]}], 
-              MarkdownParse`MarkdownElement[
-              "Item", {"Sometimes you want the URL : ", 
-                MarkdownParse`MarkdownElement[Hyperlink, 
-                 Association["Link" -> "http://www.markitdown.net/"]], "."}], 
-              
+              MarkdownParse`MarkdownElement["Item", 
+               Association[
+               "IndentationLevel" -> 0, "IndentationType" -> None, 
+                "Content" -> {"A named link to", 
+                  MarkdownParse`MarkdownElement[Hyperlink, "MarkItDown", 
+                   First[
+                    Private`ExtractMarkdownFootnoteURL[3, Private`footFile]]],
+                   ". The easiest way to do these is to select what you want \
+to make a link and hit ", 
+                  MarkdownParse`MarkdownElement["InlineCode", "Ctrl+L"], 
+                  "."}]], 
+              MarkdownParse`MarkdownElement["Item", 
+               Association[
+               "IndentationLevel" -> 0, "IndentationType" -> None, 
+                "Content" -> {"Another named link to", 
+                  MarkdownParse`MarkdownElement[Hyperlink, 
+                   Association[
+                   "Label" -> "MarkItDown", "Link" -> 
+                    "http://www.markitdown.net/"]]}]], 
+              MarkdownParse`MarkdownElement["Item", 
+               Association[
+               "IndentationLevel" -> 0, "IndentationType" -> None, 
+                "Content" -> {"Sometimes you want the URL : ", 
+                  MarkdownParse`MarkdownElement[Hyperlink, 
+                   Association["Link" -> "http://www.markitdown.net/"]], 
+                  "."}]], 
               MarkdownParse`MarkdownElement["H2", "Horizontal rule"], 
               "A horizontal rule is a dividing line drawn across the page, \
 useful for separating blocks of text.", 
@@ -1569,36 +1780,121 @@ official",
                 " http://daringfireball.net/projects/markdown/syntax"], 
                " for more information. Be aware that this document is not \
 using the official implementation, and there may be subtle differences in \
-rendering on other platforms."}}]}, 
+rendering on other platforms."}}]}, 135 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H2", "LaTex"]]}, 
+         161 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["Item", 
+              Association[
+              "IndentationLevel" -> 0, "IndentationType" -> None, 
+               "Content" -> {"A named link to", 
+                 MarkdownParse`MarkdownElement[Hyperlink, "MarkItDown", 
+                  First[
+                   Private`ExtractMarkdownFootnoteURL[3, Private`footFile]]], 
+                 ". The easiest way to do these is to select what you want to \
+make a link and hit ", 
+                 MarkdownParse`MarkdownElement["InlineCode", "Ctrl+L"], 
+                 "."}]]]}, 164 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["Item", 
+              Association[
+              "IndentationLevel" -> 0, "IndentationType" -> None, 
+               "Content" -> {"Another named link to", 
+                 MarkdownParse`MarkdownElement[Hyperlink, 
+                  Association[
+                  "Label" -> "MarkItDown", "Link" -> 
+                   "http://www.markitdown.net/"]]}]]]}, 
+         71 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
+         9 -> {"Subexpression" -> HoldForm["Markdown"]}, 
+         192 -> {"Subexpression" -> HoldForm[Center]}, 
+         93 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H3", "Code block"]]}, 
+         86 -> {"Subexpression" -> HoldForm[
+             Association[
+             "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+              "Yet another item"]]}, 174 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["HorizontalLine"]]}, 
+         218 -> {"Subexpression" -> HoldForm["TableRow"]}, 
          22 -> {"Subexpression" -> HoldForm[Italic]}, 
-         222 -> {"Subexpression" -> HoldForm[Italic]}, 
-         132 -> {"Subexpression" -> HoldForm["inline code"]}, 
-         168 -> {"Subexpression" -> HoldForm[" http://www.markitdown.net/"]}, 
-         162 -> {"Subexpression" -> HoldForm["Item"]}, 
-         134 -> {"Subexpression" -> 
-           HoldForm[
-            "I don't recommend using more than three or four levels of \
-headings here, because, when you're smallest heading isn't too small, and \
-you're largest heading isn't too big, and you want each size up to look \
-noticeably larger and more important, there aren't any other sizes to choose \
-from."]}, 231 -> {"Subexpression" -> HoldForm[{" ", 
-              MarkdownParse`MarkdownElement[Bold, "nicely"]}]}, 
-         260 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
-         142 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["LaTex", 
-              Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]]},
-          67 -> {"Subexpression" -> HoldForm[Italic]}, 
-         46 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["ItemNumbered", {1}, "Item 1"]]}, 
-         102 -> {"Subexpression" -> HoldForm["InlineCode"]}, 
-         217 -> {"Subexpression" -> HoldForm[
+         198 -> {"Subexpression" -> HoldForm[
              MarkdownParse`MarkdownElement["TableRow", {{
                 MarkdownParse`MarkdownElement[Italic, "Still"], " "}, {" ", 
                 MarkdownParse`MarkdownElement["InlineCode", "renders"], 
                 " "}, {" ", 
                 MarkdownParse`MarkdownElement[Bold, "nicely"]}}]]}, 
-         59 -> {"Subexpression" -> HoldForm[3]}, 
-         200 -> {"Subexpression" -> HoldForm[{
+         45 -> {"Subexpression" -> HoldForm["Ordered list"]}, 
+         144 -> {"Subexpression" -> HoldForm[
+             Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]}, 
+         132 -> {"Subexpression" -> HoldForm["inline code"]}, 
+         236 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
+         91 -> {"Subexpression" -> HoldForm["H2"]}, 
+         139 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["Item", 
+              Association[
+              "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+               "inline"]]]}, 
+         138 -> {"Subexpression" -> HoldForm["LaTex is also supported:"]}, 
+         40 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H2", "Lists"]]}, 
+         77 -> {"Subexpression" -> HoldForm["Unordered list"]}, 
+         96 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["CodeBlock", 
+              Association[
+              "Language" -> "None", "Body" -> 
+               "Code blocks are useful for people who look at code or for \
+clarity of plain text content. As you can see, it uses a fixed-width \
+font."]]]}, 159 -> {"Subexpression" -> HoldForm["URLs"]}, 
+         147 -> {"Subexpression" -> HoldForm[
+             Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]},
+          13 -> {"Subexpression" -> HoldForm[Italic]}, 
+         20 -> {"Subexpression" -> 
+           HoldForm["Blank lines separate paragraphs. Markdown supports "]}, 
+         74 -> {"Subexpression" -> HoldForm["."]}, 
+         154 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["LaTeX", 
+              Association[
+              "Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]]}, 
+         6 -> {"Subexpression" -> 
+           HoldForm["This note demonstrates some of what"]}, 
+         146 -> {"Subexpression" -> HoldForm["LaTeX"]}, 
+         223 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H2", "Images"]]}, 
+         46 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["ItemNumbered", {1}, "Item 1"]]}, 
+         65 -> {"Subexpression" -> HoldForm["\:2163"]}, 
+         78 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["Item", 
+              Association[
+              "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+               "An item"]]]}, 
+         103 -> {"Subexpression" -> HoldForm["inline code"]}, 
+         14 -> {"Subexpression" -> 
+           HoldForm[
+            "Note: Feel free to play with this page. Unlike regular notes, \
+this doesn't automatically save itself."]}, 
+         36 -> {"Subexpression" -> HoldForm[Bold]}, 
+         8 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
+         60 -> {"Subexpression" -> HoldForm["Number 3"]}, 
+         32 -> {"Subexpression" -> HoldForm[Italic]}, 
+         235 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[
+             Hyperlink, "introduction", 
+              " http://daringfireball.net/projects/markdown/basics"]]}, 
+         80 -> {"Subexpression" -> HoldForm[
+             Association[
+             "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+              "An item"]]}, 
+         238 -> {"Subexpression" -> 
+           HoldForm[" http://daringfireball.net/projects/markdown/basics"]}, 
+         55 -> {"Subexpression" -> HoldForm["A second item"]}, 
+         120 -> {"Subexpression" -> HoldForm[Italic]}, 
+         27 -> {"Subexpression" -> HoldForm["bold"]}, 
+         108 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[
+             "BlockQuote", 
+              "Here is a quote. What this is should be self explanatory. \
+Quotes are automatically indented when they are used."]]}, 
+         226 -> {"Subexpression" -> 
+           HoldForm["Markdown can also contain images."]}, 
+         181 -> {"Subexpression" -> HoldForm[{
               MarkdownParse`MarkdownElement[
               "TableHeader", {"Markdown ", " Less ", " Pretty"}], 
               MarkdownParse`MarkdownElement[
@@ -1611,183 +1907,120 @@ from."]}, 231 -> {"Subexpression" -> HoldForm[{" ",
                   MarkdownParse`MarkdownElement[Bold, "nicely"]}}], 
                MarkdownParse`MarkdownElement[
                "TableRow", {"1 ", " 2 ", " 3"}]}}]}, 
-         31 -> {"Subexpression" -> HoldForm[
+         143 -> {"Subexpression" -> HoldForm["LaTeX"]}, 
+         84 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["Item", 
+              Association[
+              "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+               "Yet another item"]]]}, 
+         177 -> {"Subexpression" -> HoldForm["H2"]}, 
+         67 -> {"Subexpression" -> HoldForm[Italic]}, 
+         34 -> {"Subexpression" -> HoldForm["a "]}, 
+         124 -> {"Subexpression" -> HoldForm[Bold]}, 
+         58 -> {"Subexpression" -> HoldForm[{3}]}, 
+         118 -> {"Subexpression" -> HoldForm["Headings "]}, 
+         165 -> {"Subexpression" -> HoldForm["Item"]}, 
+         157 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H2", "URLs"]]}, 
+         163 -> {"Subexpression" -> HoldForm[
+             Association[
+             "IndentationLevel" -> 0, "IndentationType" -> None, 
+              "Content" -> {"A named link to", 
+                MarkdownParse`MarkdownElement[Hyperlink, "MarkItDown", 
+                 First[
+                  Private`ExtractMarkdownFootnoteURL[3, Private`footFile]]], 
+                ". The easiest way to do these is to select what you want to \
+make a link and hit ", 
+                MarkdownParse`MarkdownElement["InlineCode", "Ctrl+L"], 
+                "."}]]}, 229 -> {"Subexpression" -> HoldForm[
+             Association[
+             "AltText" -> "Streetview of Palm Trees by Brandon Erlinger-Ford",
+               "Link" -> 
+              "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
+ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
+format&fit=crop&w=564&q=80"]]}, 
+         72 -> {"Subexpression" -> HoldForm["Roman numeral four"]}, 
+         16 -> {"Subexpression" -> HoldForm["H2"]}, 
+         121 -> {"Subexpression" -> HoldForm["can"]}, 
+         115 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H3", {"Headings ", 
+               MarkdownParse`MarkdownElement[Italic, "can"], " also contain ", 
+               MarkdownParse`MarkdownElement[Bold, "formatting"]}]]}, 
+         48 -> {"Subexpression" -> HoldForm[{1}]}, 
+         51 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[
+             "ItemNumbered", {2}, "A second item"]]}, 
+         210 -> {"Subexpression" -> HoldForm["renders"]}, 
+         201 -> {"Subexpression" -> HoldForm[{
+              MarkdownParse`MarkdownElement[Italic, "Still"], " "}]}, 
+         231 -> {"Subexpression" -> HoldForm["H2"]}, 
+         206 -> {"Subexpression" -> HoldForm[{" ", 
+              MarkdownParse`MarkdownElement["InlineCode", "renders"], " "}]}, 
+         219 -> {"Subexpression" -> HoldForm[{"1 ", " 2 ", " 3"}]}, 
+         33 -> {"Subexpression" -> HoldForm[{"a ", 
+              MarkdownParse`MarkdownElement[Bold, "bold"], " in an italic"}]},
+          182 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[
+             "TableHeader", {"Markdown ", " Less ", " Pretty"}]]}, 
+         150 -> {"Subexpression" -> HoldForm[
+             Association[
+             "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+              "presented"]]}, 167 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["Item", 
+              Association[
+              "IndentationLevel" -> 0, "IndentationType" -> None, 
+               "Content" -> {"Sometimes you want the URL : ", 
+                 MarkdownParse`MarkdownElement[Hyperlink, 
+                  Association["Link" -> "http://www.markitdown.net/"]], 
+                 "."}]]]}, 31 -> {"Subexpression" -> HoldForm[
              MarkdownParse`MarkdownElement[Italic, {"a ", 
                MarkdownParse`MarkdownElement[Bold, "bold"], 
-               " in an italic"}]]}, 193 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["HorizontalLine"]]}, 
-         246 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Hyperlink, 
-              Association[
-              "AltText" -> 
-               "Streetview of Palm Trees by Brandon Erlinger-Ford", "Link" -> 
-               "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
-ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
-format&fit=crop&w=564&q=80"]]]}, 127 -> {"Subexpression" -> HoldForm["H3"]}, 
-         219 -> {"Subexpression" -> HoldForm[{{
-               MarkdownParse`MarkdownElement[Italic, "Still"], " "}, {" ", 
-               MarkdownParse`MarkdownElement["InlineCode", "renders"], " "}, {
-              " ", 
-               MarkdownParse`MarkdownElement[Bold, "nicely"]}}]}, 
-         78 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["Item", "An item"]]}, 
-         20 -> {"Subexpression" -> 
-           HoldForm["Blank lines separate paragraphs. Markdown supports "]}, 
-         99 -> {"Subexpression" -> HoldForm[{"You can also make ", 
-              MarkdownParse`MarkdownElement["InlineCode", "inline code"], 
-              " to add insert code block formatting anywhere."}]}, 
-         66 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             Italic, {
-              "Note: the fourth item uses the Unicode character for", 
-               MarkdownParse`MarkdownElement[
-               Hyperlink, "Roman numeral four", 
-                " http://www.fileformat.info/info/unicode/char/2163/index.\
-htm"], "."}]]}, 166 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
-         70 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             Hyperlink, "Roman numeral four", 
-              " http://www.fileformat.info/info/unicode/char/2163/index.htm"]]\
-}, 197 -> {"Subexpression" -> HoldForm["Tables"]}, 
-         74 -> {"Subexpression" -> HoldForm["."]}, 
-         38 -> {"Subexpression" -> HoldForm[" in an italic"]}, 
-         91 -> {"Subexpression" -> HoldForm["H2"]}, 
-         111 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H2", "Headings"]]}, 
-         199 -> {"Subexpression" -> HoldForm["Table"]}, 
-         218 -> {"Subexpression" -> HoldForm["TableRow"]}, 
-         80 -> {"Subexpression" -> HoldForm["An item"]}, 
-         229 -> {"Subexpression" -> HoldForm["renders"]}, 
-         76 -> {"Subexpression" -> HoldForm["H3"]}, 
-         124 -> {"Subexpression" -> HoldForm[Bold]}, 
-         123 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Bold, "formatting"]]}, 
-         143 -> {"Subexpression" -> HoldForm["LaTex"]}, 
-         94 -> {"Subexpression" -> HoldForm["H3"]}, 
-         133 -> {
-          "Subexpression" -> 
-           HoldForm[
-            "Of course, demonstrating what headings look like messes up the \
-structure of the page."]}, 174 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["Item", {"Another named link to", 
-               MarkdownParse`MarkdownElement[Hyperlink, 
-                Association[
-                "Label" -> "MarkItDown", "Link" -> 
-                 "http://www.markitdown.net/"]]}]]}, 
-         30 -> {"Subexpression" -> 
-           HoldForm["Lines can have nested styling as well, like "]}, 
-         8 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
+               " in an italic"}]]}, 
+         50 -> {"Subexpression" -> HoldForm["Item 1"]}, 
+         104 -> {"Subexpression" -> 
+           HoldForm[" to add insert code block formatting anywhere."]}, 
          10 -> {"Subexpression" -> 
            HoldForm[" http://daringfireball.net/projects/markdown/"]}, 
-         62 -> {"Subexpression" -> HoldForm["ItemNumbered"]}, 
-         16 -> {"Subexpression" -> HoldForm["H2"]}, 
-         191 -> {"Subexpression" -> HoldForm["Horizontal rule"]}, 
-         118 -> {"Subexpression" -> HoldForm["Headings "]}, 
-         192 -> {"Subexpression" -> 
+         199 -> {"Subexpression" -> HoldForm["TableRow"]}, 
+         94 -> {"Subexpression" -> HoldForm["H3"]}, 
+         56 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["ItemNumbered", {3}, "Number 3"]]},
+          190 -> {
+          "Subexpression" -> HoldForm[{{Center}, {Center}, {Center}}]}, 
+         173 -> {"Subexpression" -> 
            HoldForm[
             "A horizontal rule is a dividing line drawn across the page, \
 useful for separating blocks of text."]}, 
-         26 -> {"Subexpression" -> HoldForm[Bold]}, 
-         114 -> {"Subexpression" -> 
-           HoldForm[
-            "Markdown supports six levels of headings; corresponding with the \
-six levels of HTML headings. You've probably noticed them already in the \
-page. Each level down uses one more hash character."]}, 
-         259 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             Hyperlink, "syntax", 
-              " http://daringfireball.net/projects/markdown/syntax"]]}, 
-         81 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["Item", "Another item"]]}, 
-         36 -> {"Subexpression" -> HoldForm[Bold]}, 
-         71 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
-         29 -> {"Subexpression" -> 
-           HoldForm[{"Lines can have nested styling as well, like ", 
-              MarkdownParse`MarkdownElement[Italic, {"a ", 
-                MarkdownParse`MarkdownElement[Bold, "bold"], 
-                " in an italic"}], "."}]}, 101 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["InlineCode", "inline code"]]}, 
-         151 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["LaTex", 
+         11 -> {"Subexpression" -> HoldForm[" is capable of doing."]}, 
+         111 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H2", "Headings"]]}, 
+         186 -> {"Subexpression" -> HoldForm[" Less "]}, 
+         17 -> {"Subexpression" -> HoldForm["Basic formatting"]}, 
+         5 -> {"Subexpression" -> 
+           HoldForm[{"This note demonstrates some of what", 
+              MarkdownParse`MarkdownElement[
+              Hyperlink, "Markdown", 
+               " http://daringfireball.net/projects/markdown/"], 
+              " is capable of doing."}]}, 
+         148 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["Item", 
               Association[
-              "Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]]}, 
-         122 -> {"Subexpression" -> HoldForm[" also contain "]}, 
-         113 -> {"Subexpression" -> HoldForm["Headings"]}, 
-         157 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H2", "URLs"]]}, 
-         225 -> {"Subexpression" -> HoldForm[{" ", 
-              MarkdownParse`MarkdownElement["InlineCode", "renders"], " "}]}, 
-         125 -> {"Subexpression" -> HoldForm["formatting"]}, 
-         52 -> {"Subexpression" -> HoldForm["ItemNumbered"]}, 
-         54 -> {"Subexpression" -> HoldForm[2]}, 
-         56 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["ItemNumbered", {3}, "Number 3"]]},
-          163 -> {"Subexpression" -> HoldForm[{"A named link to", 
-              MarkdownParse`MarkdownElement[
-              Hyperlink, "MarkItDown", " http://www.markitdown.net/"], 
-              ". The easiest way to do these is to select what you want to \
-make a link and hit ", 
-              MarkdownParse`MarkdownElement["InlineCode", "Ctrl+L"], "."}]}, 
-         129 -> {"Subexpression" -> HoldForm["They can even contain "]}, 
-         242 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H2", "Images"]]}, 
-         216 -> {"Subexpression" -> HoldForm[{
-              MarkdownParse`MarkdownElement["TableRow", {{
-                 MarkdownParse`MarkdownElement[Italic, "Still"], " "}, {" ", 
-                 MarkdownParse`MarkdownElement["InlineCode", "renders"], 
-                 " "}, {" ", 
-                 MarkdownParse`MarkdownElement[Bold, "nicely"]}}], 
-              MarkdownParse`MarkdownElement[
-              "TableRow", {"1 ", " 2 ", " 3"}]}]}, 
-         100 -> {"Subexpression" -> HoldForm["You can also make "]}, 
-         121 -> {"Subexpression" -> HoldForm["can"]}, 
-         175 -> {"Subexpression" -> HoldForm["Item"]}, 
-         89 -> {"Subexpression" -> HoldForm["And there's more..."]}, 
-         119 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Italic, "can"]]}, 
-         128 -> {"Subexpression" -> HoldForm[{"They can even contain ", 
-              MarkdownParse`MarkdownElement["InlineCode", "inline code"]}]}, 
-         209 -> {"Subexpression" -> HoldForm[{{Center}, {Center}, {Center}}]},
-          179 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
-         58 -> {"Subexpression" -> HoldForm[{3}]}, 
-         223 -> {"Subexpression" -> HoldForm["Still"]}, 
-         24 -> {"Subexpression" -> HoldForm[" and "]}, 
-         184 -> {"Subexpression" -> 
-           HoldForm["Sometimes you want the URL : "]}, 
-         106 -> {"Subexpression" -> HoldForm["H3"]}, 
-         233 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Bold, "nicely"]]}, 
-         249 -> {"Subexpression" -> HoldForm[
+              "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+               "presented"]]]}, 98 -> {"Subexpression" -> HoldForm[
+             Association[
+             "Language" -> "None", "Body" -> 
+              "Code blocks are useful for people who look at code or for \
+clarity of plain text content. As you can see, it uses a fixed-width \
+font."]]}, 63 -> {"Subexpression" -> HoldForm[{4}]}, 
+         76 -> {"Subexpression" -> HoldForm["H3"]}, 
+         204 -> {"Subexpression" -> HoldForm["Still"]}, 
+         105 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H3", "Quote"]]}, 
+         3 -> {"Subexpression" -> HoldForm["H1"]}, 
+         230 -> {"Subexpression" -> HoldForm[
              MarkdownParse`MarkdownElement["H2", "Last"]]}, 
-         34 -> {"Subexpression" -> HoldForm["a "]}, 
-         213 -> {"Subexpression" -> HoldForm[Center]}, 
-         215 -> {"Subexpression" -> HoldForm[Center]}, 
-         117 -> {"Subexpression" -> HoldForm[{"Headings ", 
-              MarkdownParse`MarkdownElement[Italic, "can"], " also contain ", 
-              
-              MarkdownParse`MarkdownElement[Bold, "formatting"]}]}, 
-         82 -> {"Subexpression" -> HoldForm["Item"]}, 
-         108 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             "BlockQuote", 
-              "Here is a quote. What this is should be self explanatory. \
-Quotes are automatically indented when they are used."]]}, 
-         149 -> {"Subexpression" -> HoldForm["Item"]}, 
-         136 -> {"Subexpression" -> HoldForm["H2"]}, 
-         43 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H3", "Ordered list"]]}, 
-         173 -> {"Subexpression" -> HoldForm["."]}, 
-         86 -> {"Subexpression" -> HoldForm["Yet another item"]}, 
-         212 -> {"Subexpression" -> HoldForm[{Center}]}, 
-         241 -> {"Subexpression" -> HoldForm[" 3"]}, 
-         126 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H3", {"They can even contain ", 
-               MarkdownParse`MarkdownElement["InlineCode", "inline code"]}]]},
-          40 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H2", "Lists"]]}, 
-         238 -> {"Subexpression" -> HoldForm[{"1 ", " 2 ", " 3"}]}, 
-         116 -> {"Subexpression" -> HoldForm["H3"]}, 
-         252 -> {"Subexpression" -> 
+         140 -> {"Subexpression" -> HoldForm["Item"]}, 
+         233 -> {"Subexpression" -> 
            HoldForm[{
              "There's actually a lot more to Markdown than this. See the \
 official", 
@@ -1799,220 +2032,57 @@ official",
                " http://daringfireball.net/projects/markdown/syntax"], 
               " for more information. Be aware that this document is not \
 using the official implementation, and there may be subtle differences in \
-rendering on other platforms."}]}, 
-         88 -> {"Subexpression" -> HoldForm["Item"]}, 
-         169 -> {"Subexpression" -> 
+rendering on other platforms."}]}, 43 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H3", "Ordered list"]]}, 
+         134 -> {"Subexpression" -> 
            HoldForm[
-            ". The easiest way to do these is to select what you want to make \
-a link and hit "]}, 187 -> {"Subexpression" -> HoldForm[
-             Association["Link" -> "http://www.markitdown.net/"]]}, 
-         85 -> {"Subexpression" -> HoldForm["Item"]}, 
-         50 -> {"Subexpression" -> HoldForm["Item 1"]}, 
-         211 -> {"Subexpression" -> HoldForm[Center]}, 
-         177 -> {"Subexpression" -> HoldForm["Another named link to"]}, 
-         245 -> {"Subexpression" -> 
-           HoldForm["Markdown can also contain images."]}, 
-         240 -> {"Subexpression" -> HoldForm[" 2 "]}, 
-         75 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H3", "Unordered list"]]}, 
-         104 -> {"Subexpression" -> 
-           HoldForm[" to add insert code block formatting anywhere."]}, 
-         79 -> {"Subexpression" -> HoldForm["Item"]}, 
-         186 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
-         227 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["InlineCode", "renders"]]}, 
-         51 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             "ItemNumbered", {2}, "A second item"]]}, 
-         146 -> {"Subexpression" -> HoldForm["LaTex"]}, 
-         98 -> {"Subexpression" -> HoldForm[
-             Association[
-             "Language" -> "None", "Body" -> 
-              "Code blocks are useful for people who look at code or for \
-clarity of plain text content. As you can see, it uses a fixed-width \
-font."]]}, 189 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H2", "Horizontal rule"]]}, 
-         159 -> {"Subexpression" -> HoldForm["URLs"]}, 
-         23 -> {"Subexpression" -> HoldForm["italic"]}, 
-         196 -> {"Subexpression" -> HoldForm["H2"]}, 
-         90 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H2", "Paragraph modifiers"]]}, 
-         180 -> {"Subexpression" -> HoldForm[
-             Association[
-             "Label" -> "MarkItDown", "Link" -> 
-              "http://www.markitdown.net/"]]}, 
-         49 -> {"Subexpression" -> HoldForm[1]}, 
-         7 -> {"Subexpression" -> HoldForm[
+            "I don't recommend using more than three or four levels of \
+headings here, because, when you're smallest heading isn't too small, and \
+you're largest heading isn't too big, and you want each size up to look \
+noticeably larger and more important, there aren't any other sizes to choose \
+from."]}, 87 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["Item", 
+              Association[
+              "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+               "And there's more..."]]]}, 
+         133 -> {"Subexpression" -> 
+           HoldForm[
+            "Of course, demonstrating what headings look like messes up the \
+structure of the page."]}, 7 -> {"Subexpression" -> HoldForm[
              MarkdownParse`MarkdownElement[
              Hyperlink, "Markdown", 
               " http://daringfireball.net/projects/markdown/"]]}, 
-         14 -> {"Subexpression" -> 
-           HoldForm[
-            "Note: Feel free to play with this page. Unlike regular notes, \
-this doesn't automatically save itself."]}, 
-         251 -> {"Subexpression" -> HoldForm["Last"]}, 
-         39 -> {"Subexpression" -> HoldForm["."]}, 
-         148 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["Item", "presented"]]}, 
-         256 -> {"Subexpression" -> HoldForm["introduction"]}, 
-         32 -> {"Subexpression" -> HoldForm[Italic]}, 
-         45 -> {"Subexpression" -> HoldForm["Ordered list"]}, 
-         37 -> {"Subexpression" -> HoldForm["bold"]}, 
-         261 -> {"Subexpression" -> HoldForm["syntax"]}, 
-         2 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H1", "An exhibit of Markdown"]]}, 
-         182 -> {"Subexpression" -> HoldForm["Item"]}, 
-         254 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             Hyperlink, "introduction", 
-              " http://daringfireball.net/projects/markdown/basics"]]}, 
-         25 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Bold, "bold"]]}, 
-         150 -> {"Subexpression" -> HoldForm["presented"]}, 
-         55 -> {"Subexpression" -> HoldForm["A second item"]}, 
-         110 -> {"Subexpression" -> 
-           HoldForm[
-            "Here is a quote. What this is should be self explanatory. Quotes \
-are automatically indented when they are used."]}, 
-         44 -> {"Subexpression" -> HoldForm["H3"]}, 
-         130 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["InlineCode", "inline code"]]}, 
-         60 -> {"Subexpression" -> HoldForm["Number 3"]}, 
-         103 -> {"Subexpression" -> HoldForm["inline code"]}, 
-         237 -> {"Subexpression" -> HoldForm["TableRow"]}, 
-         87 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["Item", "And there's more..."]]}, 
-         27 -> {"Subexpression" -> HoldForm["bold"]}, 
-         139 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["Item", "inline"]]}, 
-         93 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H3", "Code block"]]}, 
-         214 -> {"Subexpression" -> HoldForm[{Center}]}, 
-         65 -> {"Subexpression" -> HoldForm["\:2163"]}, 
-         247 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
-         147 -> {"Subexpression" -> HoldForm[
-             Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]},
-          253 -> {
-          "Subexpression" -> 
-           HoldForm[
-            "There's actually a lot more to Markdown than this. See the \
-official"]}, 202 -> {"Subexpression" -> HoldForm["TableHeader"]}, 
-         53 -> {"Subexpression" -> HoldForm[{2}]}, 
-         183 -> {"Subexpression" -> HoldForm[{"Sometimes you want the URL : ", 
-              MarkdownParse`MarkdownElement[Hyperlink, 
-               Association["Link" -> "http://www.markitdown.net/"]], "."}]}, 
-         145 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["LaTex", 
-              Association[
-              "Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]]}, 
-         77 -> {"Subexpression" -> HoldForm["Unordered list"]}, 
-         61 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["ItemNumbered", {4}, "\:2163"]]}, 
-         152 -> {"Subexpression" -> HoldForm["LaTex"]}, 
-         15 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H2", "Basic formatting"]]}, 
-         33 -> {"Subexpression" -> HoldForm[{"a ", 
-              MarkdownParse`MarkdownElement[Bold, "bold"], " in an italic"}]},
-          165 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             Hyperlink, "MarkItDown", " http://www.markitdown.net/"]]}, 
-         194 -> {"Subexpression" -> HoldForm["HorizontalLine"]}, 
-         181 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[
-             "Item", {"Sometimes you want the URL : ", 
-               MarkdownParse`MarkdownElement[Hyperlink, 
-                Association["Link" -> "http://www.markitdown.net/"]], "."}]]},
-          96 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["CodeBlock", 
-              Association[
-              "Language" -> "None", "Body" -> 
-               "Code blocks are useful for people who look at code or for \
-clarity of plain text content. As you can see, it uses a fixed-width \
-font."]]]}, 205 -> {"Subexpression" -> HoldForm[" Less "]}, 
-         248 -> {"Subexpression" -> HoldForm[
-             Association[
-             "AltText" -> "Streetview of Palm Trees by Brandon Erlinger-Ford",
-               "Link" -> 
-              "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
-ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
-format&fit=crop&w=564&q=80"]]}, 155 -> {"Subexpression" -> HoldForm["LaTex"]},
-          235 -> {"Subexpression" -> HoldForm["nicely"]}, 
-         239 -> {"Subexpression" -> HoldForm["1 "]}, 
-         9 -> {"Subexpression" -> HoldForm["Markdown"]}, 
-         206 -> {"Subexpression" -> HoldForm[" Pretty"]}, 
-         92 -> {"Subexpression" -> HoldForm["Paragraph modifiers"]}, 
-         13 -> {"Subexpression" -> HoldForm[Italic]}, 
-         221 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Italic, "Still"]]}, 
-         144 -> {"Subexpression" -> HoldForm[
-             Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]}, 
-         18 -> {"Subexpression" -> 
-           HoldForm[
-            "Write Paragraphs like so. A paragraph is the basic block of \
-Markdown. A paragraph is what text will turn into when there is no reason it \
-should become anything else."]}, 
-         141 -> {"Subexpression" -> HoldForm["inline"]}, 
-         4 -> {"Subexpression" -> HoldForm["An exhibit of Markdown"]}, 
-         158 -> {"Subexpression" -> HoldForm["H2"]}, 
-         243 -> {"Subexpression" -> HoldForm["H2"]}, 
-         63 -> {"Subexpression" -> HoldForm[{4}]}, 
-         137 -> {"Subexpression" -> HoldForm["LaTex"]}, 
-         6 -> {"Subexpression" -> 
-           HoldForm["This note demonstrates some of what"]}, 
-         135 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H2", "LaTex"]]}, 
-         5 -> {"Subexpression" -> 
-           HoldForm[{"This note demonstrates some of what", 
+         97 -> {"Subexpression" -> HoldForm["CodeBlock"]}, 
+         214 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[Bold, "nicely"]]}, 
+         152 -> {"Subexpression" -> HoldForm["LaTeX"]}, 
+         189 -> {"Subexpression" -> HoldForm["TableAlignment"]}, 
+         197 -> {"Subexpression" -> HoldForm[{
+              MarkdownParse`MarkdownElement["TableRow", {{
+                 MarkdownParse`MarkdownElement[Italic, "Still"], " "}, {" ", 
+                 MarkdownParse`MarkdownElement["InlineCode", "renders"], 
+                 " "}, {" ", 
+                 MarkdownParse`MarkdownElement[Bold, "nicely"]}}], 
               MarkdownParse`MarkdownElement[
-              Hyperlink, "Markdown", 
-               " http://daringfireball.net/projects/markdown/"], 
-              " is capable of doing."}]}, 
-         195 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H2", "Tables"]]}, 
-         154 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["LaTex", 
-              Association[
-              "Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]]}, 
-         203 -> {"Subexpression" -> 
-           HoldForm[{"Markdown ", " Less ", " Pretty"}]}, 
-         164 -> {"Subexpression" -> HoldForm["A named link to"]}, 
-         109 -> {"Subexpression" -> HoldForm["BlockQuote"]}, 
-         255 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
-         172 -> {"Subexpression" -> HoldForm["Ctrl+L"]}, 
-         228 -> {"Subexpression" -> HoldForm["InlineCode"]}, 
-         131 -> {"Subexpression" -> HoldForm["InlineCode"]}, 
-         72 -> {"Subexpression" -> HoldForm["Roman numeral four"]}, 
-         115 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["H3", {"Headings ", 
-               MarkdownParse`MarkdownElement[Italic, "can"], " also contain ", 
-               MarkdownParse`MarkdownElement[Bold, "formatting"]}]]}, 
-         263 -> {"Subexpression" -> 
-           HoldForm[
-            " for more information. Be aware that this document is not using \
-the official implementation, and there may be subtle differences in rendering \
-on other platforms."]}, 35 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement[Bold, "bold"]]}, 
-         204 -> {"Subexpression" -> HoldForm["Markdown "]}, 
-         236 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["TableRow", {"1 ", " 2 ", " 3"}]]},
-          262 -> {
-          "Subexpression" -> 
-           HoldForm[" http://daringfireball.net/projects/markdown/syntax"]}, 
-         69 -> {"Subexpression" -> 
-           HoldForm["Note: the fourth item uses the Unicode character for"]}, 
-         257 -> {"Subexpression" -> 
-           HoldForm[" http://daringfireball.net/projects/markdown/basics"]}, 
-         57 -> {"Subexpression" -> HoldForm["ItemNumbered"]}, 
-         170 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["InlineCode", "Ctrl+L"]]}, 
-         161 -> {"Subexpression" -> HoldForm[
-             MarkdownParse`MarkdownElement["Item", {"A named link to", 
-               MarkdownParse`MarkdownElement[
-               Hyperlink, "MarkItDown", " http://www.markitdown.net/"], 
-               ". The easiest way to do these is to select what you want to \
-make a link and hit ", 
-               MarkdownParse`MarkdownElement["InlineCode", "Ctrl+L"], "."}]]},
-          198 -> {"Subexpression" -> HoldForm[
+              "TableRow", {"1 ", " 2 ", " 3"}]}]}, 
+         188 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[
+             "TableAlignment", {{Center}, {Center}, {Center}}]]}, 
+         112 -> {"Subexpression" -> HoldForm["H2"]}, 
+         194 -> {"Subexpression" -> HoldForm[Center]}, 
+         39 -> {"Subexpression" -> HoldForm["."]}, 
+         95 -> {"Subexpression" -> HoldForm["Code block"]}, 
+         100 -> {"Subexpression" -> HoldForm["You can also make "]}, 
+         75 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H3", "Unordered list"]]}, 
+         180 -> {"Subexpression" -> HoldForm["Table"]}, 
+         196 -> {"Subexpression" -> HoldForm[Center]}, 
+         125 -> {"Subexpression" -> HoldForm["formatting"]}, 
+         208 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["InlineCode", "renders"]]}, 
+         171 -> {"Subexpression" -> HoldForm["H2"]}, 
+         239 -> {"Subexpression" -> HoldForm[" and"]}, 
+         179 -> {"Subexpression" -> HoldForm[
              MarkdownParse`MarkdownElement["Table", {
                MarkdownParse`MarkdownElement[
                "TableHeader", {"Markdown ", " Less ", " Pretty"}], 
@@ -2025,142 +2095,276 @@ make a link and hit ",
                    MarkdownParse`MarkdownElement[Bold, "nicely"]}}], 
                 MarkdownParse`MarkdownElement[
                 "TableRow", {"1 ", " 2 ", " 3"}]}}]]}, 
-         47 -> {"Subexpression" -> HoldForm["ItemNumbered"]}, 
+         191 -> {"Subexpression" -> HoldForm[{Center}]}, 
+         128 -> {"Subexpression" -> HoldForm[{"They can even contain ", 
+              MarkdownParse`MarkdownElement["InlineCode", "inline code"]}]}, 
+         207 -> {"Subexpression" -> HoldForm[" "]}, 
+         25 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[Bold, "bold"]]}, 
+         158 -> {"Subexpression" -> HoldForm["H2"]}, 
+         160 -> {"Subexpression" -> 
+           HoldForm["Add hyperlinks in the following ways:"]}, 
+         237 -> {"Subexpression" -> HoldForm["introduction"]}, 
+         28 -> {"Subexpression" -> HoldForm[" formatting."]}, 
+         44 -> {"Subexpression" -> HoldForm["H3"]}, 
+         205 -> {"Subexpression" -> HoldForm[" "]}, 
+         184 -> {"Subexpression" -> 
+           HoldForm[{"Markdown ", " Less ", " Pretty"}]}, 
+         216 -> {"Subexpression" -> HoldForm["nicely"]}, 
+         232 -> {"Subexpression" -> HoldForm["Last"]}, 
+         66 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[
+             Italic, {
+              "Note: the fourth item uses the Unicode character for", 
+               MarkdownParse`MarkdownElement[
+               Hyperlink, "Roman numeral four", 
+                " http://www.fileformat.info/info/unicode/char/2163/index.\
+htm"], "."}]]}, 59 -> {"Subexpression" -> HoldForm[3]}, 
+         52 -> {"Subexpression" -> HoldForm["ItemNumbered"]}, 
+         145 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["LaTeX", 
+              Association[
+              "Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]]]}, 
+         122 -> {"Subexpression" -> HoldForm[" also contain "]}, 
+         178 -> {"Subexpression" -> HoldForm["Tables"]}, 
+         203 -> {"Subexpression" -> HoldForm[Italic]}, 
+         23 -> {"Subexpression" -> HoldForm["italic"]}, 
+         126 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H3", {"They can even contain ", 
+               MarkdownParse`MarkdownElement["InlineCode", "inline code"]}]]},
+          4 -> {"Subexpression" -> HoldForm["An exhibit of Markdown"]}, 
+         15 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H2", "Basic formatting"]]}, 
+         21 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[Italic, "italic"]]}, 
+         82 -> {"Subexpression" -> HoldForm["Item"]}, 
+         224 -> {"Subexpression" -> HoldForm["H2"]}, 
+         68 -> {"Subexpression" -> 
+           HoldForm[{"Note: the fourth item uses the Unicode character for", 
+              MarkdownParse`MarkdownElement[
+              Hyperlink, "Roman numeral four", 
+               " http://www.fileformat.info/info/unicode/char/2163/index.htm"]\
+, "."}]}, 195 -> {"Subexpression" -> HoldForm[{Center}]}, 
+         54 -> {"Subexpression" -> HoldForm[2]}, 
+         155 -> {"Subexpression" -> HoldForm["LaTeX"]}, 
+         136 -> {"Subexpression" -> HoldForm["H2"]}, 
+         242 -> {"Subexpression" -> HoldForm["syntax"]}, 
+         37 -> {"Subexpression" -> HoldForm["bold"]}, 
+         137 -> {"Subexpression" -> HoldForm["LaTex"]}, 
+         99 -> {"Subexpression" -> HoldForm[{"You can also make ", 
+              MarkdownParse`MarkdownElement["InlineCode", "inline code"], 
+              " to add insert code block formatting anywhere."}]}, 
+         35 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[Bold, "bold"]]}, 
+         127 -> {"Subexpression" -> HoldForm["H3"]}, 
+         110 -> {"Subexpression" -> 
+           HoldForm[
+            "Here is a quote. What this is should be self explanatory. Quotes \
+are automatically indented when they are used."]}, 
+         151 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["LaTeX", 
+              Association[
+              "Type" -> "Display", "Body" -> "a^n + b^n = c^n"]]]}, 
+         141 -> {"Subexpression" -> HoldForm[
+             Association[
+             "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+              "inline"]]}, 64 -> {"Subexpression" -> HoldForm[4]}, 
+         220 -> {"Subexpression" -> HoldForm["1 "]}, 
+         18 -> {"Subexpression" -> 
+           HoldForm[
+            "Write Paragraphs like so. A paragraph is the basic block of \
+Markdown. A paragraph is what text will turn into when there is no reason it \
+should become anything else."]}, 213 -> {"Subexpression" -> HoldForm[" "]}, 
+         89 -> {"Subexpression" -> HoldForm[
+             Association[
+             "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+              "And there's more..."]]}, 
+         129 -> {"Subexpression" -> HoldForm["They can even contain "]}, 
+         156 -> {"Subexpression" -> HoldForm[
+             Association[
+             "Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]]}, 
+         217 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["TableRow", {"1 ", " 2 ", " 3"}]]},
+          81 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["Item", 
+              Association[
+              "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+               "Another item"]]]}, 
+         117 -> {"Subexpression" -> HoldForm[{"Headings ", 
+              MarkdownParse`MarkdownElement[Italic, "can"], " also contain ", 
+              
+              MarkdownParse`MarkdownElement[Bold, "formatting"]}]}, 
+         187 -> {"Subexpression" -> HoldForm[" Pretty"]}, 
          19 -> {"Subexpression" -> 
            HoldForm[{"Blank lines separate paragraphs. Markdown supports ", 
               MarkdownParse`MarkdownElement[Italic, "italic"], " and ", 
               MarkdownParse`MarkdownElement[Bold, "bold"], " formatting."}]}, 
-         107 -> {"Subexpression" -> HoldForm["Quote"]}, 
-         140 -> {"Subexpression" -> HoldForm["Item"]}, 
-         3 -> {"Subexpression" -> HoldForm["H1"]}, 
-         97 -> {"Subexpression" -> HoldForm["CodeBlock"]}, 
-         12 -> {"Subexpression" -> HoldForm[
+         222 -> {"Subexpression" -> HoldForm[" 3"]}, 
+         193 -> {"Subexpression" -> HoldForm[{Center}]}, 
+         114 -> {"Subexpression" -> 
+           HoldForm[
+            "Markdown supports six levels of headings; corresponding with the \
+six levels of HTML headings. You've probably noticed them already in the \
+page. Each level down uses one more hash character."]}, 
+         53 -> {"Subexpression" -> HoldForm[{2}]}, 
+         38 -> {"Subexpression" -> HoldForm[" in an italic"]}, 
+         202 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[Italic, "Still"]]}, 
+         240 -> {"Subexpression" -> HoldForm[
              MarkdownParse`MarkdownElement[
-             Italic, "Note: Feel free to play with this page. Unlike regular \
-notes, this doesn't automatically save itself."]]}}, FormatType -> 
+             Hyperlink, "syntax", 
+              " http://daringfireball.net/projects/markdown/syntax"]]}, 
+         162 -> {"Subexpression" -> HoldForm["Item"]}, 
+         70 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[
+             Hyperlink, "Roman numeral four", 
+              " http://www.fileformat.info/info/unicode/char/2163/index.htm"]]\
+}, 113 -> {"Subexpression" -> HoldForm["Headings"]}, 
+         185 -> {"Subexpression" -> HoldForm["Markdown "]}, 
+         170 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["H2", "Horizontal rule"]]}, 
+         227 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement[Hyperlink, 
+              Association[
+              "AltText" -> 
+               "Streetview of Palm Trees by Brandon Erlinger-Ford", "Link" -> 
+               "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
+ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
+format&fit=crop&w=564&q=80"]]]}, 88 -> {"Subexpression" -> HoldForm["Item"]}, 
+         61 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["ItemNumbered", {4}, "\:2163"]]}, 
+         69 -> {"Subexpression" -> 
+           HoldForm["Note: the fourth item uses the Unicode character for"]}, 
+         142 -> {"Subexpression" -> HoldForm[
+             MarkdownParse`MarkdownElement["LaTeX", 
+              Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]]]},
+          241 -> {"Subexpression" -> HoldForm[Hyperlink]}, 
+         209 -> {"Subexpression" -> HoldForm["InlineCode"]}, 
+         85 -> {"Subexpression" -> HoldForm["Item"]}, 
+         168 -> {"Subexpression" -> HoldForm["Item"]}, 
+         107 -> {"Subexpression" -> HoldForm["Quote"]}, 
+         106 -> {"Subexpression" -> HoldForm["H3"]}}, FormatType -> 
        StandardForm, 
        VertexLabels -> {
-        70 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 238 -> 
-         Placed[List, Tooltip], 255 -> Placed[
-           HoldForm[Hyperlink], Tooltip], 68 -> Placed[List, Tooltip], 177 -> 
-         Placed[
-           HoldForm["Another named link to"], Tooltip], 93 -> 
+        70 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 238 -> Placed[
+           HoldForm[" http://daringfireball.net/projects/markdown/basics"], 
+           Tooltip], 68 -> Placed[List, Tooltip], 177 -> Placed[
+           HoldForm["H2"], Tooltip], 93 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 200 -> 
          Placed[List, Tooltip], 234 -> Placed[
-           HoldForm[Bold], Tooltip], 59 -> Placed[
+           HoldForm[
+           "There's actually a lot more to Markdown than this. See the \
+official"], Tooltip], 59 -> Placed[
            HoldForm[3], Tooltip], 13 -> Placed[
            HoldForm[Italic], Tooltip], 187 -> Placed[
-           HoldForm[
-            Association["Link" -> "http://www.markitdown.net/"]], Tooltip], 
-         131 -> Placed[
+           HoldForm[" Pretty"], Tooltip], 131 -> Placed[
            HoldForm["InlineCode"], Tooltip], 107 -> Placed[
            HoldForm["Quote"], Tooltip], 18 -> Placed[
            HoldForm[
            "Write Paragraphs like so. A paragraph is the basic block of \
 Markdown. A paragraph is what text will turn into when there is no reason it \
 should become anything else."], Tooltip], 47 -> Placed[
-           HoldForm["ItemNumbered"], Tooltip], 190 -> Placed[
-           HoldForm["H2"], Tooltip], 193 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 189 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 250 -> Placed[
-           HoldForm["H2"], Tooltip], 88 -> Placed[
-           HoldForm["Item"], Tooltip], 251 -> Placed[
-           HoldForm["Last"], Tooltip], 6 -> Placed[
+           HoldForm["ItemNumbered"], Tooltip], 190 -> Placed[List, Tooltip], 
+         193 -> Placed[List, Tooltip], 189 -> Placed[
+           HoldForm["TableAlignment"], Tooltip], 88 -> Placed[
+           HoldForm["Item"], Tooltip], 6 -> Placed[
            HoldForm["This note demonstrates some of what"], Tooltip], 233 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 254 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 121 -> Placed[
-           HoldForm["can"], Tooltip], 181 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 20 -> Placed[
+         Placed[List, Tooltip], 121 -> Placed[
+           HoldForm["can"], Tooltip], 181 -> Placed[List, Tooltip], 20 -> 
+         Placed[
            HoldForm["Blank lines separate paragraphs. Markdown supports "], 
            Tooltip], 81 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 
-         164 -> Placed[
-           HoldForm["A named link to"], Tooltip], 136 -> Placed[
+         164 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 136 -> 
+         Placed[
            HoldForm["H2"], Tooltip], 199 -> Placed[
-           HoldForm["Table"], Tooltip], 216 -> Placed[List, Tooltip], 227 -> 
+           HoldForm["TableRow"], Tooltip], 216 -> Placed[
+           HoldForm["nicely"], Tooltip], 227 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 108 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 17 -> Placed[
            HoldForm["Basic formatting"], Tooltip], 82 -> Placed[
-           HoldForm["Item"], Tooltip], 246 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 259 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 138 -> Placed[
-           HoldForm["LaTex is also supported:"], Tooltip], 209 -> 
-         Placed[List, Tooltip], 261 -> Placed[
-           HoldForm["syntax"], Tooltip], 53 -> Placed[List, Tooltip], 175 -> 
+           HoldForm["Item"], Tooltip], 138 -> Placed[
+           HoldForm["LaTex is also supported:"], Tooltip], 209 -> Placed[
+           HoldForm["InlineCode"], Tooltip], 53 -> Placed[List, Tooltip], 175 -> 
          Placed[
-           HoldForm["Item"], Tooltip], 51 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 231 -> 
-         Placed[List, Tooltip], 23 -> Placed[
+           HoldForm["HorizontalLine"], Tooltip], 51 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 231 -> Placed[
+           HoldForm["H2"], Tooltip], 23 -> Placed[
            HoldForm["italic"], Tooltip], 46 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 153 -> Placed[
            HoldForm[
             Association["Type" -> "Display", "Body" -> "a^n + b^n = c^n"]], 
            Tooltip], 39 -> Placed[
            HoldForm["."], Tooltip], 97 -> Placed[
-           HoldForm["CodeBlock"], Tooltip], 252 -> Placed[List, Tooltip], 24 -> 
-         Placed[
+           HoldForm["CodeBlock"], Tooltip], 24 -> Placed[
            HoldForm[" and "], Tooltip], 241 -> Placed[
-           HoldForm[" 3"], Tooltip], 213 -> Placed[
-           HoldForm[Center], Tooltip], 178 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 172 -> Placed[
-           HoldForm["Ctrl+L"], Tooltip], 12 -> 
+           HoldForm[Hyperlink], Tooltip], 213 -> Placed[
+           HoldForm[" "], Tooltip], 178 -> Placed[
+           HoldForm["Tables"], Tooltip], 172 -> Placed[
+           HoldForm["Horizontal rule"], Tooltip], 12 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 54 -> Placed[
            HoldForm[2], Tooltip], 25 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 173 -> Placed[
-           HoldForm["."], Tooltip], 145 -> 
+           HoldForm[
+           "A horizontal rule is a dividing line drawn across the page, \
+useful for separating blocks of text."], Tooltip], 145 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 160 -> Placed[
            HoldForm["Add hyperlinks in the following ways:"], Tooltip], 80 -> 
          Placed[
-           HoldForm["An item"], Tooltip], 87 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 197 -> Placed[
-           HoldForm["Tables"], Tooltip], 31 -> 
+           HoldForm[
+            Association[
+            "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+             "An item"]], Tooltip], 87 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 197 -> 
+         Placed[List, Tooltip], 31 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 174 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 210 -> 
-         Placed[List, Tooltip], 123 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 210 -> Placed[
+           HoldForm["renders"], Tooltip], 123 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 64 -> Placed[
            HoldForm[4], Tooltip], 124 -> Placed[
            HoldForm[Bold], Tooltip], 29 -> Placed[List, Tooltip], 170 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 91 -> Placed[
            HoldForm["H2"], Tooltip], 226 -> Placed[
-           HoldForm[" "], Tooltip], 95 -> Placed[
+           HoldForm["Markdown can also contain images."], Tooltip], 95 -> 
+         Placed[
            HoldForm["Code block"], Tooltip], 211 -> Placed[
-           HoldForm[Center], Tooltip], 218 -> Placed[
+           HoldForm[" "], Tooltip], 218 -> Placed[
            HoldForm["TableRow"], Tooltip], 94 -> Placed[
            HoldForm["H3"], Tooltip], 89 -> Placed[
-           HoldForm["And there's more..."], Tooltip], 219 -> 
-         Placed[List, Tooltip], 96 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 230 -> Placed[
-           HoldForm[" "], Tooltip], 77 -> Placed[
-           HoldForm["Unordered list"], Tooltip], 185 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 45 -> Placed[
-           HoldForm["Ordered list"], Tooltip], 3 -> Placed[
-           HoldForm["H1"], Tooltip], 214 -> Placed[List, Tooltip], 195 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 201 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 166 -> Placed[
-           HoldForm[Hyperlink], Tooltip], 184 -> Placed[
-           HoldForm["Sometimes you want the URL : "], Tooltip], 248 -> 
-         Placed[
            HoldForm[
             Association[
-            "AltText" -> "Streetview of Palm Trees by Brandon Erlinger-Ford", 
-             "Link" -> 
-             "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
-ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
-format&fit=crop&w=564&q=80"]], Tooltip], 256 -> Placed[
-           HoldForm["introduction"], Tooltip], 186 -> Placed[
-           HoldForm[Hyperlink], Tooltip], 55 -> Placed[
+            "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+             "And there's more..."]], Tooltip], 219 -> Placed[List, Tooltip], 
+         96 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 230 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 77 -> Placed[
+           HoldForm["Unordered list"], Tooltip], 185 -> Placed[
+           HoldForm["Markdown "], Tooltip], 45 -> Placed[
+           HoldForm["Ordered list"], Tooltip], 3 -> Placed[
+           HoldForm["H1"], Tooltip], 214 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 195 -> 
+         Placed[List, Tooltip], 201 -> Placed[List, Tooltip], 166 -> Placed[
+           HoldForm[
+            Association[
+            "IndentationLevel" -> 0, "IndentationType" -> None, 
+             "Content" -> {"Another named link to", 
+               MarkdownParse`MarkdownElement[Hyperlink, 
+                Association[
+                "Label" -> "MarkItDown", "Link" -> 
+                 "http://www.markitdown.net/"]]}]], Tooltip], 184 -> 
+         Placed[List, Tooltip], 186 -> Placed[
+           HoldForm[" Less "], Tooltip], 55 -> Placed[
            HoldForm["A second item"], Tooltip], 32 -> Placed[
            HoldForm[Italic], Tooltip], 128 -> Placed[List, Tooltip], 110 -> 
          Placed[
            HoldForm[
            "Here is a quote. What this is should be self explanatory. Quotes \
-are automatically indented when they are used."], Tooltip], 235 -> Placed[
-           HoldForm["nicely"], Tooltip], 84 -> 
+are automatically indented when they are used."], Tooltip], 235 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 84 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 75 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 202 -> Placed[
-           HoldForm["TableHeader"], Tooltip], 223 -> Placed[
-           HoldForm["Still"], Tooltip], 237 -> Placed[
-           HoldForm["TableRow"], Tooltip], 236 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 92 -> Placed[
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 202 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 223 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 237 -> Placed[
+           HoldForm["introduction"], Tooltip], 236 -> Placed[
+           HoldForm[Hyperlink], Tooltip], 92 -> Placed[
            HoldForm["Paragraph modifiers"], Tooltip], 147 -> Placed[
            HoldForm[
             Association["Type" -> "Inline", "Body" -> " a^2 + b^2 = c^2 "]], 
@@ -2172,64 +2376,64 @@ are automatically indented when they are used."], Tooltip], 235 -> Placed[
          Placed[MarkdownParse`MarkdownElement, Tooltip], 21 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 137 -> Placed[
            HoldForm["LaTex"], Tooltip], 171 -> Placed[
-           HoldForm["InlineCode"], Tooltip], 247 -> Placed[
-           HoldForm[Hyperlink], Tooltip], 112 -> Placed[
+           HoldForm["H2"], Tooltip], 112 -> Placed[
            HoldForm["H2"], Tooltip], 224 -> Placed[
-           HoldForm[" "], Tooltip], 35 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 207 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 58 -> 
-         Placed[List, Tooltip], 113 -> Placed[
+           HoldForm["H2"], Tooltip], 35 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 207 -> Placed[
+           HoldForm[" "], Tooltip], 58 -> Placed[List, Tooltip], 113 -> Placed[
            HoldForm["Headings"], Tooltip], 101 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 38 -> Placed[
            HoldForm[" in an italic"], Tooltip], 105 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 228 -> Placed[
-           HoldForm["InlineCode"], Tooltip], 120 -> Placed[
+           HoldForm[Hyperlink], Tooltip], 120 -> Placed[
            HoldForm[Italic], Tooltip], 159 -> Placed[
            HoldForm["URLs"], Tooltip], 169 -> Placed[
            HoldForm[
-           ". The easiest way to do these is to select what you want to make \
-a link and hit "], Tooltip], 78 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 212 -> 
-         Placed[List, Tooltip], 126 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 240 -> Placed[
-           HoldForm[" 2 "], Tooltip], 61 -> 
+            Association[
+            "IndentationLevel" -> 0, "IndentationType" -> None, 
+             "Content" -> {"Sometimes you want the URL : ", 
+               MarkdownParse`MarkdownElement[Hyperlink, 
+                Association["Link" -> "http://www.markitdown.net/"]], "."}]], 
+           Tooltip], 78 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 
+         212 -> Placed[List, Tooltip], 126 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 240 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 61 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 72 -> Placed[
            HoldForm["Roman numeral four"], Tooltip], 176 -> 
-         Placed[List, Tooltip], 142 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 142 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 60 -> Placed[
            HoldForm["Number 3"], Tooltip], 48 -> Placed[List, Tooltip], 155 -> 
          Placed[
-           HoldForm["LaTex"], Tooltip], 132 -> Placed[
+           HoldForm["LaTeX"], Tooltip], 132 -> Placed[
            HoldForm["inline code"], Tooltip], 41 -> Placed[
            HoldForm["H2"], Tooltip], 85 -> Placed[
-           HoldForm["Item"], Tooltip], 208 -> Placed[
-           HoldForm["TableAlignment"], Tooltip], 63 -> Placed[List, Tooltip], 
-         109 -> Placed[
-           HoldForm["BlockQuote"], Tooltip], 179 -> Placed[
-           HoldForm[Hyperlink], Tooltip], 5 -> Placed[List, Tooltip], 102 -> 
-         Placed[
+           HoldForm["Item"], Tooltip], 208 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 63 -> 
+         Placed[List, Tooltip], 109 -> Placed[
+           HoldForm["BlockQuote"], Tooltip], 179 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 5 -> 
+         Placed[List, Tooltip], 102 -> Placed[
            HoldForm["InlineCode"], Tooltip], 139 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 258 -> Placed[
-           HoldForm[" and"], Tooltip], 134 -> Placed[
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 134 -> Placed[
            HoldForm[
            "I don't recommend using more than three or four levels of \
 headings here, because, when you're smallest heading isn't too small, and \
 you're largest heading isn't too big, and you want each size up to look \
 noticeably larger and more important, there aren't any other sizes to choose \
 from."], Tooltip], 154 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 167 -> 
-         Placed[
-           HoldForm["MarkItDown"], Tooltip], 28 -> Placed[
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 28 -> Placed[
            HoldForm[" formatting."], Tooltip], 156 -> Placed[
            HoldForm[
             Association["Type" -> "Display", "Body" -> " a^2 + b^2 = c^2 "]], 
            Tooltip], 198 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 
          127 -> Placed[
            HoldForm["H3"], Tooltip], 192 -> Placed[
-           HoldForm[
-           "A horizontal rule is a dividing line drawn across the page, \
-useful for separating blocks of text."], Tooltip], 9 -> Placed[
+           HoldForm[Center], Tooltip], 9 -> Placed[
            HoldForm["Markdown"], Tooltip], 86 -> Placed[
-           HoldForm["Yet another item"], Tooltip], 119 -> 
+           HoldForm[
+            Association[
+            "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+             "Yet another item"]], Tooltip], 119 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 129 -> Placed[
            HoldForm["They can even contain "], Tooltip], 149 -> Placed[
            HoldForm["Item"], Tooltip], 30 -> Placed[
@@ -2238,12 +2442,16 @@ useful for separating blocks of text."], Tooltip], 9 -> Placed[
            HoldForm[1], Tooltip], 44 -> Placed[
            HoldForm["H3"], Tooltip], 36 -> Placed[
            HoldForm[Bold], Tooltip], 150 -> Placed[
-           HoldForm["presented"], Tooltip], 67 -> Placed[
+           HoldForm[
+            Association[
+            "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+             "presented"]], Tooltip], 67 -> Placed[
            HoldForm[Italic], Tooltip], 76 -> Placed[
            HoldForm["H3"], Tooltip], 116 -> Placed[
-           HoldForm["H3"], Tooltip], 220 -> Placed[List, Tooltip], 243 -> 
-         Placed[
-           HoldForm["H2"], Tooltip], 98 -> Placed[
+           HoldForm["H3"], Tooltip], 220 -> Placed[
+           HoldForm["1 "], Tooltip], 243 -> Placed[
+           HoldForm[" http://daringfireball.net/projects/markdown/syntax"], 
+           Tooltip], 98 -> Placed[
            HoldForm[
             Association[
             "Language" -> "None", "Body" -> 
@@ -2254,296 +2462,297 @@ clarity of plain text content. As you can see, it uses a fixed-width font."]],
            "Markdown supports six levels of headings; corresponding with the \
 six levels of HTML headings. You've probably noticed them already in the \
 page. Each level down uses one more hash character."], Tooltip], 122 -> Placed[
-           HoldForm[" also contain "], Tooltip], 245 -> Placed[
-           HoldForm["Markdown can also contain images."], Tooltip], 135 -> 
+           HoldForm[" also contain "], Tooltip], 135 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 232 -> Placed[
-           HoldForm[" "], Tooltip], 217 -> 
+           HoldForm["Last"], Tooltip], 217 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 204 -> Placed[
-           HoldForm["Markdown "], Tooltip], 161 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 165 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 2 -> 
+           HoldForm["Still"], Tooltip], 161 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 165 -> Placed[
+           HoldForm["Item"], Tooltip], 2 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 104 -> Placed[
            HoldForm[" to add insert code block formatting anywhere."], 
-           Tooltip], 182 -> Placed[
-           HoldForm["Item"], Tooltip], 157 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 106 -> Placed[
+           Tooltip], 182 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 
+         157 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 106 -> 
+         Placed[
            HoldForm["H3"], Tooltip], 27 -> Placed[
-           HoldForm["bold"], Tooltip], 260 -> Placed[
-           HoldForm[Hyperlink], Tooltip], 65 -> Placed[
+           HoldForm["bold"], Tooltip], 65 -> Placed[
            HoldForm["\:2163"], Tooltip], 42 -> Placed[
            HoldForm["Lists"], Tooltip], 26 -> Placed[
            HoldForm[Bold], Tooltip], 37 -> Placed[
            HoldForm["bold"], Tooltip], 8 -> Placed[
            HoldForm[Hyperlink], Tooltip], 83 -> Placed[
-           HoldForm["Another item"], Tooltip], 117 -> Placed[List, Tooltip], 
-         215 -> Placed[
-           HoldForm[Center], Tooltip], 163 -> Placed[List, Tooltip], 71 -> 
+           HoldForm[
+            Association[
+            "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+             "Another item"]], Tooltip], 117 -> Placed[List, Tooltip], 215 -> 
          Placed[
+           HoldForm[Bold], Tooltip], 163 -> Placed[
+           HoldForm[
+            Association[
+            "IndentationLevel" -> 0, "IndentationType" -> None, 
+             "Content" -> {"A named link to", 
+               MarkdownParse`MarkdownElement[Hyperlink, "MarkItDown", 
+                First[
+                 Private`ExtractMarkdownFootnoteURL[3, Private`footFile]]], 
+               ". The easiest way to do these is to select what you want to \
+make a link and hit ", 
+               MarkdownParse`MarkdownElement["InlineCode", "Ctrl+L"], "."}]], 
+           Tooltip], 71 -> Placed[
            HoldForm[Hyperlink], Tooltip], 50 -> Placed[
            HoldForm["Item 1"], Tooltip], 15 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 115 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 183 -> 
-         Placed[List, Tooltip], 148 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 183 -> Placed[
+           HoldForm["TableHeader"], Tooltip], 148 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 244 -> Placed[
-           HoldForm["Images"], Tooltip], 180 -> Placed[
            HoldForm[
-            Association[
-            "Label" -> "MarkItDown", "Link" -> "http://www.markitdown.net/"]],
-            Tooltip], 100 -> Placed[
+           " for more information. Be aware that this document is not using \
+the official implementation, and there may be subtle differences in rendering \
+on other platforms."], Tooltip], 180 -> Placed[
+           HoldForm["Table"], Tooltip], 100 -> Placed[
            HoldForm["You can also make "], Tooltip], 4 -> Placed[
            HoldForm["An exhibit of Markdown"], Tooltip], 143 -> Placed[
-           HoldForm["LaTex"], Tooltip], 125 -> Placed[
+           HoldForm["LaTeX"], Tooltip], 125 -> Placed[
            HoldForm["formatting"], Tooltip], 11 -> Placed[
            HoldForm[" is capable of doing."], Tooltip], 7 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 66 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 229 -> Placed[
-           HoldForm["renders"], Tooltip], 34 -> Placed[
+           HoldForm[
+            Association[
+            "AltText" -> "Streetview of Palm Trees by Brandon Erlinger-Ford", 
+             "Link" -> 
+             "https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
+ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
+format&fit=crop&w=564&q=80"]], Tooltip], 34 -> Placed[
            HoldForm["a "], Tooltip], 74 -> Placed[
            HoldForm["."], Tooltip], 16 -> Placed[
            HoldForm["H2"], Tooltip], 111 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 191 -> Placed[
-           HoldForm["Horizontal rule"], Tooltip], 69 -> Placed[
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 191 -> 
+         Placed[List, Tooltip], 69 -> Placed[
            HoldForm["Note: the fourth item uses the Unicode character for"], 
            Tooltip], 43 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 1 -> 
          Placed[List, Tooltip], 133 -> Placed[
            HoldForm[
            "Of course, demonstrating what headings look like messes up the \
 structure of the page."], Tooltip], 130 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 203 -> 
-         Placed[List, Tooltip], 14 -> Placed[
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 203 -> Placed[
+           HoldForm[Italic], Tooltip], 14 -> Placed[
            HoldForm[
            "Note: Feel free to play with this page. Unlike regular notes, \
-this doesn't automatically save itself."], Tooltip], 257 -> Placed[
-           HoldForm[" http://daringfireball.net/projects/markdown/basics"], 
-           Tooltip], 152 -> Placed[
-           HoldForm["LaTex"], Tooltip], 263 -> Placed[
-           HoldForm[
-           " for more information. Be aware that this document is not using \
-the official implementation, and there may be subtle differences in rendering \
-on other platforms."], Tooltip], 262 -> Placed[
-           HoldForm[" http://daringfireball.net/projects/markdown/syntax"], 
-           Tooltip], 56 -> Placed[MarkdownParse`MarkdownElement, Tooltip], 
-         144 -> Placed[
+this doesn't automatically save itself."], Tooltip], 152 -> Placed[
+           HoldForm["LaTeX"], Tooltip], 56 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 144 -> Placed[
            HoldForm[
             Association["Type" -> "Inline", "Body" -> "a^2 + b^2 = c^2"]], 
            Tooltip], 141 -> Placed[
-           HoldForm["inline"], Tooltip], 99 -> Placed[List, Tooltip], 151 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 249 -> 
+           HoldForm[
+            Association[
+            "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+             "inline"]], Tooltip], 99 -> Placed[List, Tooltip], 151 -> 
          Placed[MarkdownParse`MarkdownElement, Tooltip], 62 -> Placed[
            HoldForm["ItemNumbered"], Tooltip], 162 -> Placed[
            HoldForm["Item"], Tooltip], 222 -> Placed[
-           HoldForm[Italic], Tooltip], 40 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 221 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 205 -> Placed[
-           HoldForm[" Less "], Tooltip], 253 -> Placed[
-           HoldForm[
-           "There's actually a lot more to Markdown than this. See the \
-official"], Tooltip], 158 -> Placed[
+           HoldForm[" 3"], Tooltip], 40 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 221 -> Placed[
+           HoldForm[" 2 "], Tooltip], 205 -> Placed[
+           HoldForm[" "], Tooltip], 158 -> Placed[
            HoldForm["H2"], Tooltip], 118 -> Placed[
            HoldForm["Headings "], Tooltip], 239 -> Placed[
-           HoldForm["1 "], Tooltip], 196 -> Placed[
-           HoldForm["H2"], Tooltip], 79 -> Placed[
-           HoldForm["Item"], Tooltip], 242 -> 
-         Placed[MarkdownParse`MarkdownElement, Tooltip], 225 -> 
-         Placed[List, Tooltip], 168 -> Placed[
-           HoldForm[" http://www.markitdown.net/"], Tooltip], 52 -> Placed[
+           HoldForm[" and"], Tooltip], 196 -> Placed[
+           HoldForm[Center], Tooltip], 79 -> Placed[
+           HoldForm["Item"], Tooltip], 242 -> Placed[
+           HoldForm["syntax"], Tooltip], 225 -> Placed[
+           HoldForm["Images"], Tooltip], 168 -> Placed[
+           HoldForm["Item"], Tooltip], 52 -> Placed[
            HoldForm["ItemNumbered"], Tooltip], 10 -> Placed[
            HoldForm[" http://daringfireball.net/projects/markdown/"], 
            Tooltip], 140 -> Placed[
-           HoldForm["Item"], Tooltip], 206 -> Placed[
-           HoldForm[" Pretty"], Tooltip], 188 -> Placed[
-           HoldForm["."], Tooltip], 146 -> Placed[
-           HoldForm["LaTex"], Tooltip], 103 -> Placed[
+           HoldForm["Item"], Tooltip], 206 -> Placed[List, Tooltip], 188 -> 
+         Placed[MarkdownParse`MarkdownElement, Tooltip], 146 -> Placed[
+           HoldForm["LaTeX"], Tooltip], 103 -> Placed[
            HoldForm["inline code"], Tooltip], 33 -> Placed[List, Tooltip], 
          194 -> Placed[
-           HoldForm["HorizontalLine"], Tooltip], 57 -> Placed[
+           HoldForm[Center], Tooltip], 57 -> Placed[
            HoldForm["ItemNumbered"], Tooltip]}}]]}, 
     TagBox[GraphicsGroupBox[{
        {Hue[0.6, 0.7, 0.5], Opacity[0.7], Arrowheads[0.], 
         ArrowBox[CompressedData["
-1:eJxt2Xk4lF34OPCxxNjGzJh9MTMovUj2ojJ3oUWJeEUoWqQk4VXRQlKSJamk
-iJI3WoREaZMtpF5JKVHZl4QUZYl8Xdfvd33/cH9dlz/u63M/55xnmfOc+zyi
-LXvsPaUIBIKMBIEgSfh//0G/bp3Zx2FBtWZ5g8xrOpxNmPxEOMgBixfPO5ad
-Y8NMX9eUdqx4MR2yHkd6yl3nIf9+a11fexYddPqnZtccpiIf7srIa//MAq/G
-qwdCZLFf0vlm+nADC6wOuhuHWDKRswqDHTRzyeC7ZdRkQJKC/JX1y1OldyhA
-nGeYxXjFxcfrlUVd+skDy1tWjdXlNOS7rTgLuyZVoCRjjM3dTUf+0Ne2oI1B
-hda8Fe5Om/DxMZQwOdo7Glxc2hbeJ4/7dzYeF9+7T4VXXo2DHzpZyO3070oo
-jVHgQ9ntlHARPv+DMtqZux7xIbUtect7ZTLy8weyN9zfx4GUt/4ltzrw9ekJ
-X7Fe0oIHTEpCWkEmPr/otNhBL08m0Lk9d0R++PjgkK1RIWYMcDt2oqE0BY+/
-T9uHLruABtZfI2MbZ+Pxp1yUf+4qy4dPk7rtTRQGcnPG3z1PErlQ2d/TM5CA
-2//ryNeA1e9pUP258F3yD/z8/Nc0uDAjgAHUArbJ3WgScoPkGytbN7Pg+Nk2
-rcQ5HOQ5YwfrJt3ZsJ68TSA8jl09oSGvuYMDdLkqwu5c3L9P3yBvvw4b/ixr
-GCV34fO7YX7ldvwOEnj78qwvqGM/sGBk3unVLHD+pWeXpKuEveii5V9CJowX
-7XxdE4uP937ufP1oCwu+2362OrwMP5+qefaLq/p5oByxfOCdMr4/SVojAyGd
-TNC2f2u2ZgU+vk3h2okWJToYTV504+/E9yeIpLnu6fT1s7T2u9p+Fs8ftPOV
-cwvauVBXP3qDGY3bZz976+39nQshKpH18bvw+FKtLhJ/2bFh3Pz+zRwD/Hxm
-K59b2/KUC/21woiFC1SQN5n1f7CL48GDOfxq8SI8/rl5kmSn02z4eJRirtiO
-fx+2K6ul8x5TQTHZVVBlpIiv75DJw9kPOdDbQHDbthA/f6LPLcElrkwwSb0b
-mZvER74j3eac/WYGBLMUxmr+4PMb3KYEdq5sKIlJuFI/ia9fxxzT97q76MBd
-+nAFowKPvy3bluAez4MbF8erMuLw9VHweGNybJ4ahP+RkBtKw8/X+7zPot/2
-TNAi8xLccvH9Jb7+ZePXy4DHVirXlSVw/1UtOX4u8TT4L3izc/kE7t97LzfM
-fRcXuiknOwojcfsB+0ZE8S48SO79Qt/jqYreV2nE7rQqPR4k5NTe9vqXi5z+
-6pKrSRUXljHe+LzR56H32cDLmy+vpdDA7y+zT8X+AuRnlKTHMuuo0N7KsTBr
-FSI/Qh2pUpp+f/gMJ/dtNxSg/LN3s1wvzKFCjNFK0DFXQ37CuTsrWYYCTw4z
-XFh/RMiDC2o7sqMosGi8gLVkvhp635rfu15uJEuD3aZRDcZFZOT5PYKTBxbT
-YP1n2y0d2mT0Pg4476nenc6GKt1HnOugjDy75swx/yEWZHb0njvkr4zex1MF
-C1Y/a1eCe20m973rlJCXCzZkPbEgQsufran7VEnI3eYwq430FcFdV1izTomM
-3G/7me1arXIQv0fhEqtEAbnU0l0nk58pgpmhR8S2AhLq76jy5cK2XEnocJfr
-T41XRA6isIKSVVKQNng6tX+BAurPcrhpjobELKiOsN/bk0ZEbp4w1UpSkYG9
-85LYFldk0XrEwVHzQOYjZRic5WP6iaqKvPxuOhHuEUFTKyRKy1WIvPjYFU5B
-1vR56ddnLI7lo/yXFnW1hEfSkH89OrRbLEKucSrqZ3fAlJjUXGCiEaCG4sJn
-N+PCD42JD/kSSOEB6sgP0Y/UzEr8Ib6dKqH4tB/73DPr+vV5I2KPy/Osc0Xq
-KJ/gGxT4GjrEc7/7r6ClaSC/sLu2qut+j3ituCmspV8DrdeWNshd1u4QAPNj
-yIbrpSrIt2taVkwpCQESvfZobKGh9Vzp1x8mfztQIKI+JI80hd0iU88w0J8C
-eYW3TgYn4PVehc3UspupJEj7z3TRmBINufZNwxcHGYowJciMfZqggnxtuabb
-BEkZamOkmYdBBeV7HJl/qnSrDDhlUn0cmCpoPTk/XPrC6U8qoPfJydhn+v7P
-9J7OUP1VwVSw9LaXdXZXRW50uknfRkcFljlcPW5lwEf5Yfs2Kla/IEMixAlN
-3YRovTqgdudi8Sky5Hhde1afxkGuohCv3U4hQUxozAmpAezWXaHUuWpkUBaX
-19ycZKP8NYl7qxPbiaDvt5Zq58hD6+F5B0zruiNIYJJcl3eVxEJu91eb52CD
-AgxwfxbWL8dufkolr8+EBFqcG5Y67v9HfuDWxc1LZCAxhiFyIrPRentvZdu3
-Ob0CePKeujNJTxH5q277H4P6IiD6lSi8N5FBcbpHhPZyCzWw+7EwbNFiKeQe
-bmW27z6rQW3Ui0LOxIR4pisxdtzljonAife8f2CWJMqXMesKHNqpDv+G+gRM
-nh0Sz3RSlINszBN1iOmxcmztHUZ+zCCUunRAHXxd9JoanUfEM+uJ4JWD8Z8K
-uHC+y/6ZZxMJ1RudjkVPPWx4EJlwMldGUhnVGzuNJ8P2/VKFlQ5uzTR9XI8A
-kTJQ8lEVdgb06Rb/wPXIfZctFX+smeB8W3fxy+NKyI/TjLzk4hlwU7C/2c9C
-CdUrkqINh64l0cDpXVd1Cp+DPGHqSStvKx2q0yKf9YVxUD0zR+joUz5CgV3J
-R4/0rWAh927YHzsrjgL0k1qlEYVMVO84TSWHhIwLIFBvg0l7DAN5g86K8li2
-EEiVrVl3W3E99PKqL3y/wIf+KacEyXAO8glJZ+l8sip8a07tFDE5qF6K0v+i
-of8vFZqG6qPfTs9zM71G78b97l9UaPwR+964i4zqKRfG8mZLLzp8+mpmvc5A
-Drng5+radCs6VDh8KfxPOAt5vkN541xjBrwJ47woeUdE+ZVNPmfkx2iwUnN9
-wx21KfFMb1z5Jni/GQ2kr53YVt44JZ5Zz2VkM76MDrDA7dTX3m0dPFTvWVGG
-jirZs4CiazhU/YGH6r1txlGXHr5hwzeqtER4NB/5fL1RDbeI6Xnq+9ASS0c+
-qgc1ZdXlju7gQX6u2sb8c2TkkucakpV+8+BOYP7O0REyqge3X2xdHXeICM5n
-11o8sGIgJ45/SWm1nBQfMekQN4bimPZ5vHLTkiFxbd6LD14sJvILW32/xph2
-iT8X34wL9MQ+XDgg9UZ+SJyo6/JOYIzbD3qzSMn9Zae448+2itSfdNQeIame
-2LM8Viw34c6ZjGEiP+K+fg81PlucU7F57pQ1C7VHOL7N1MU1Vdw+fEy12ZKO
-/f//aTmeLeRKMFC9fGrJZk+TeBakCLaU7QySRd6hnZQh2siCR+rijXsFEihe
-dOtaYFEgCx6qk1VWnRgRz3Tiuhsft9uyYG4N7VS63jfxzHhk+LzrhRYmeETm
-qNXEvkHe6LYk43cGC8hccVfQrjfimfW4mEex4U4KwHh3whu7Y0xUrxtIjK9O
-7RRA5NSjx3YCFqrH1xo2SXFGqRAYqPpZ7gUbeeSWfELiRhVwKdTzj/PkoHr9
-7Sqjj9wnbFBYOhEfKctD/jSsMj33wvTvaG2fmVInF9Xzg5MLvcbEqvDh1YNE
-+Z0qyNdFqdd3bFaFlO/ht8zm0lC9f5YrI1gMqlC8POjyijIWctPR3yWxUarw
-aXTipxqThfYDPqwrWl7wmA0hH7Pf7ktXRJ5QcCxNcQ8HNMrTO4+nKqL9godP
-063qSKrQqPlAtMCTglyy6OBK03mqsN3x92y36Xpo5n6CROvpHJGuAG4+L1PJ
-l+Egvx7ZN+4XJoBLffKsvl1stJ+Qfqye5gYUeOy/IEvVRxb54rrjnzTTFYDI
-kCKoFE6IZ8bUp8H+/k1EWPgo4fNTu2HkCzOtKzoKZSDyW6jDoSUdyJPCqu2l
-S2VhtJzasMv1F3LyHvUSzy/ScMjgRZ/a/kHkE3XHhfMXyEMMOXOslDyE+pOe
-0lwzR1UaCD/CorS8zyPfxI4L2imQAkLY6h1de0uQ97jcyTp3YNb/zgMzx+PC
-b1ZetF8CCttXEnVvt6Dxnmv3P//3XgKQl5qt/mXcKZ65X/OvZUHs6T9c+Etv
-ssrsIxHt5zQfl27ZepcHfTakYfdBSRQHrDy6ZOwyHySvpWT7ff0tnunORy+5
-jbFUgfzdldDsMSyeGV/b7JB7bakARkuWR3lqdSJPEl7OenhYFewOhA2zr7SL
-Z+4n3by/L2XHMiZoVC5mVCwRov2m4tLK8/uvMuBrWdNUC08NxX4TJQKrlwyo
-pklfaglSR25+/fhA6tT0+miCKpEboIH8ZmrfOZ2J6XnbNPykvZ86yleirtzT
-K8UA55GAa/ya2chvvpza/9OcDoOJF1M1Smaj/bChpTdMNYl0eMeKnqPTRkKe
-Hnew+lMQHXrV3w+GFyqj/TBDzkHfXfoq4Py5YK9PGd4PU8q2XaVkK4CCTAWN
-4+0U5Ocqbq9Knf79ntHjpt2Ip6L9sly5Zfm+R9Wh9Gnyj+RGBvLsO6FndCc1
-4eEW5m2HbUwUt80d+nZPSwuc/bqHy1xx/krjtB5SiBZEBO8MIZznIIczvoEb
-wnWgZmABc0ERA7Xn6PXSoldRG7SjR9u/eWPvMI78LRrWhma/rdYeGnQUf9Rm
-3qrr1oF/Ol4sGpyez2d696bxWfnFOlAe2EzjVqggP62/IdO9VwcIVNbmQWc6
-Op89Bd9sil20YZ77643DQVzkax6Y3Yi/qwMJGYY5cXF8FFeFZXSTBubBwdzN
-BbU2AuTpjsFrslm6UFFzLeiThyryOe/7Z6slzYM5q89mBNcLUHv2yw5/j2vU
-he38TgWKgxC1d6FNXcpFMB8g0s2CPU+A2huKazRQsdeF2U6nrA+VCtH9IrXn
-tDkK9YBB7JE6LaYjjyAOStq80oUcwxwyu5SJ8lPv1nFZSXoQTh5ZFH6Hhtzm
-ZJ/T01Z9MJc5EWk0pILig4WD15McDIDt5Gd2cjYF+W5OYt0XmiFMqnGdH7ZQ
-kTvZ+Pf59BiAtd7ejLhFdNRerdyHgE3bDSCw7tWm6N+KyC8WJQhSSw3Aff06
-RmUAGeVfkRw8ZN5qAJchRNZTXgH5080vv44XGkDif2mSe97KofFaVNJThOcN
-4dXZe6+Vp+ucmZ5+cnbz+j+GMGhLYeyRw7463Dd9y0lDcN0a3DUqjfPpR+9r
-TB4wAoNv9LE4FgV5ZqjkYH+MEfzbZ2ARO0pB14v/YJXnYjdDEJ4t/xBZS0de
-RrDLayg3BOZBw4YNJgwUE4gH85dYGEF/h+1uLQ0m8hWxRZJn7I1g/eu3hx0d
-8PNUpH+5vyd/PuSLBvt+fWUiT1TruZPorgfy/0iZFL9godhr/Jai6IseDLI9
-7vdsZSN38vQyj6nWg0K+95RwFgf5GXkjM3qrHvhO1N3yS2Kh7w3Bvjx5qwVM
-UGdr/VOjzUOuVplUzYxggCaXqfdYnoe+N3xUWsR3mp63iZMK3X9HU5EbcOU2
-GM6lwnMbmw5bhgr6HtGTXLxDcJcPdf7loZ7XuchHtEpelplMz0sp1ZOi6f5n
-fq/4EsYNvULkAzWoSKomWog88cR1w6MnBDCLwOKv+0eEXJgltaLDVhVcs55X
-mhjh45mqnsxfz/lQXe8pCy34+OQskq/3Iz4cyeq1rvERov6871ypra4SgtS3
-+L9tNqohfzf85HX0KiEEhX55NvIEu6OoJnx24vS8dpE+FJ+mhsYjPG+Q9vqo
-Kiz85Su/e4068qAYHRkteQGMP0wt2sPFvul12ULiRz7U08Z2LwF1+B++5has
-
-         "], 0.09160670148647594]}, 
+1:eJxt2Gk4lWv3AHDjNsaet23YA9qmyBzCXg0iJNPpOFQaTKdkplKJk4RGkSKK
+QqnzllmhqCRjkqkkmokk25SU3j68/y+tv+vaH+7rd9/ruZ/n3vaz1uJuC3b1
+FRUSEpr89RH532e80ahD2J4Epeq3f5ifUQZ42SdvlSgDfS1xzHNFKvC736aV
+LFTPiMK+himO+jATuXfwJg+FCzKwrGRmdrgB+xtdnliWyiIY84lOze9WQO5B
+1Izz9iVB8CfOiN8iJeSy0SRuyTlxmFm39N4ZPh05sXdj0PA6EiQGrJnxaqcg
+rzYYYq9zJ8GdsFcvhUPx9Y3aScnBJTQQPxJkKuatiLyzpizckiMDq2jydg/f
+c5CXdJuUhb2iwI37sW+ox/D+8noSO3vmxaFnoLrLJQE/X+ewh4kLo+KgEfHD
+KENCGXm6D0/qzmUKCBY1DoSYqyIPzOg0ywihgmDiFiv4Db4/+sj4wwg9IkQw
+0ld1/gfvP77xMCliizzM2cUHEmbx+jdXi3wnqCRw5zCPG8Xg9XPw1G+wXxZ2
+9RgMzUn/P8+nyPQfL6o0aP+4QVL7gM/3tfMpyi1DaZDhjy/mbWchZ9G6m611
+qDDlSrU/uRnHf+ITw2+eoYMdudYmVQ3vX+xalXGdEwV6e5bJlO7AnswYCNay
+pAFHSqumWA7H/0O6vq+mQQYcyroXcqvx94NlyR7aNyMPfdxG4Y1L8PmeVRU9
+d4IsCxXZXRd/+uPzG0hMfCVEWARz11pdSZU0/P3odN/hlkSGR3aua9ibcPyv
+H+MiKFuIoEfc6pi6Hj9fqegwhxdrZIBsb/Y++E82cgpNMu/jVRJ8ubdsg9gk
+jt/pEBbs5kEH0zPK0gkO2A+N1ZYbS9Nh5QozT0IFPr9E/c0qZ8lU2BrdMrOv
+Bf8+mHkFDrG1adBDtxgNksT7F3ontNbWjgK+ziVP/OPx+XxYStDfF08D36kH
+/uLn8f4Yb8fCaG5kCOWpKdquxutZXztFwsrlIVNj0M2Kh///Om0GWtyNaaCy
+dfqe7jN8f3f/0aio+5MIlo9OTk59ZCA/EZhwMnwnDa6wqsQtHXH8hU+D7uYs
+eWjfZn5kjy3e39ELe11snpHBYlmD5TYbvN7W6riYvycReHLHbI8F4f0tpJ7a
+4LWBCplXn3RfKsXnr5c8myP8HxV4M88S3hGC4xfMP+lKAjLMjK1OkpXB/z8q
++ZEmXu5kGHcKSQrbiM/PQ+/Zn2t+/W6L55quVevFbtmtl37oOQle1Xl8IHXg
++6dOT3WsnxSC0yqmqlWJHPS+6p4IJHuslwA5k4Blsi9ZyL0K93ZlzhPA7+iG
+xAImC73PXhFLnn33+c7/J3l9fZg6E7n7GyIrf+8E3+Jhh8MYRQG5fpJ3Z/rN
+H3zT3fmUwnAFND/HRyvyOvUl3y3g+Bub03Ts2Zfo6yjP+Hc4Y1YLHAZyZ525
+4GcxPfzLcY1Plj1moPft85Hc/UvqCCDhEbM7ylkBufKdi4onXktAFPF6cVs7
+A72PxWge1zN1pOE48ejLwyvpyJt8TywOt5ICSp5GXG4jHb2P/524YuBUKgzH
++i2yRvWpyMuaA/8tKF/gE3Z67qt3IiNn3opgZIyJgJ/H9ncW9RTkG4XGtb+W
+fuP76pHUzN2wqy/psHl8Rwi8594en26jouvZjUSNel/8yt/xyIFsVSiPvMjC
++Ohdqxn+aO3LeMvVRHQ99/dkf77LF3762lHZFV9IyPdscq46NDvBr09bM1H3
+BwnlI4oFxx0fi5Bg+7pVIYwXROSaS4Raw/kkEP3EuLt+txTyoEe7A490kMDn
+VnFy9gcimr+y+mjdx80kOK3Vb3tgpRhyn82BZ7hkEtQdWN4hJ/jG/3383Tj5
+TWM6EVrfnp/32jKBfPqm9B5aDxG2mNvLn696i9y4srj6WBwJFPyX3hl2m0Dz
+k8kmqdK/nquQYNtku1si8ixvS7FCRRII/e/v93wtMdc85o9f76d5AUFdf5iG
+8jmR4OQU1XkidLWdn+c+paF8zncdIdJ6nQK0bOL3aNUpILewktx2+LoCbGkt
+d4zbzET5nmeafO19W0nIIDRntBqoItcPOto96kCAofA5+qkC7OY/lHwobwgQ
+ZTarpT7JRfOjbtSdK/spAtU/Xu6O61VD+eQxSsLfVv+hQi+laaTtHAV5lG9X
+bH0+DVbevR1ceZmMvM1OlsqOoIHYQasl/e8oaH6RsZcbt5cOglAzRuSvPOb3
+fHUg4U3cAX8hkEv6KLHyrgryeodNZ0XV5vkltS7h/zBYyIN6MqcqLgjB1N2M
+43fiWWi+puVZL37qZ/5S+GpD8WWhfLhvOGf6AAiBQ1HDrTo3JeT9VWIJkznf
++M51pvSWSuzUfhe9IlUhuGnm/fcDVTy/7vqSy41GY3ymW7bL4EEllG+L5ohY
+JeRR4bldrX5FoRry46TN5plpNCArX+XrJS1G49h1lcyUR3Twp6vYP6nkIR8T
+tKvdH6NDVlPNzwaCJnKhHwY3eqdo4CdXcWDbcx6aT/x6pNl1iA6bay/ZHV6v
+hbzmgUW3tIUCSK/y7PVXw+6382jxXxcZ8O7snNj7DVqonljlku+goU6Hpzp1
+h/O96cgDku5ncSvpUJTbW637hI7qjSxJvfP8k/LQWnbvg7eZKnLtPGeraE85
+KD3csO2MgiqqR37OVD0vUpSDa5GerpUn6MiveJYTj6fIglGmYprUBzqqV25J
+R52aKiDCY5tiidmnXOR94Sdz5M1JcKB62eBBARfVMyE6jM0SnVIg0Dz2Uwaw
+O+eTRv9tlYSPg2mTG4W5qN45Hc+P6hYSB08PcbVAaSXk/gb5zg6RYlAz6WYa
+8UIJ1UOtS73vhHuIw35fh507n7KR73++w+PzNTGoO79s3Gc5G9VLHdtXTAbb
+00HfwZKcnMNFvv3761pGOQ3+zXHMcK3gonrqrz1kebvFTBB9Q+4yEKUjd02f
+vefarAgkv0OlmaNU5EFb3R+LX2GC3Unp7s9ldDTfrdlEwu5X3aQTInhstp2C
+/HGisL5boTJAjlPk+AMyquci/rIuHRuhQvu+b+NXJenIK+6O6r1ypoJU28uE
+BxdpqN4rIUp2zoUxQGCoaVBoz0XuQz9zM2mAAVO0n0OxklxUD1IUE0wXlCXA
+IYRT+u0xE/lD8FlV8FMCukwcRrYuZ6J6UGk4O/ZcojTImnyIn3umhlxF9uAD
+ggwBKp0PcE2/Lkbjcc9Dp7XnxIA3V109YKyBfOxW99QrfWGQa1J3jfqA3WMs
+rm3GShToHeeTr0lg38FYOD7cLgqfy4q4cTxNFM/9pu3feVHz/KaYtOFHAuz/
+6jUu3QoL/OXpLhMbFbVQPNO1TmcO8kUhI7BL7lQY9qWlnrErmoTBUOjmzrKN
+Wqhetjj5qrHoqzSkTRww6BOQkRcoquzNjpSEzVvHctokiWhcWL0QsiSPAJfD
+CYfgkzRyqdDZRKOrYtD1rT4lY68EGgfdd816f0MYjEdDW3VfiyBPGrPOm+aJ
+AoG2t2xghQiqxy8cNRx5a0mAXO9TsD2Qg7xL98VqU3sJYGcscM5mclA9vqxh
+7M/I+F95y/XGb8meKsjlym3I3HAmFHxfVn5GmYXq9QB7n/vTvQpg+ja3a8aY
+g9yppu/1W2UmVN/pTxYrYqN6/iJ7yzNbJh2Wp49IhwUrIC+U+L4k6gINYsd9
+k6hlDFTvD7/N2+AayIAjK+8vfVfFRH5x9Z65+l4GkEv9cjq8FFE/4NlQzPSc
+IxXCWLzguC9c5Pfcj6k09FOh/n3e3I+XXNQvkCyUOFfuqADmjlJCPr0qyHly
+LUaBHAUIjJWq6UlmoX7CxaaAXBsPCkz+9L86GMlFrs8qTuNcJENNc2i7dhoX
+9RNkwhXyeBkMiMqMsZ504CBPDSukclsZ0CHP87MdZaN+QySdVXFNgQgusQ+N
+9s9RkXe/ODsV0CAHArOnOVNiNNSP2Mmusd73kwHFY/J1pr/yod/dsk5KUpyt
+ADPzugRCJO5XbBh9JeVbtwhsClQ/wWEu8q03NjWNb5CF/haLtYI9XNSvEAlg
+pOlZycOLsui/yuvYqF/hGbTyw8YfNAjZvlq7b4aDfHj625kt6XQIuLPrY20V
+B/UzrltfMj+mw4F0fxgJjMH9DvWJDJpOpTo8KRWOZK/CY80KpwsHmniwoDZn
+xW5RQZ7GFb+cwNcAzsF5bqUfE3mW60V7tV+/W4/zGuK7lFRQPLlv6xlmVzTg
+ucTRFqFP2A831XI/7dGEdzzTcsouNhr7l8Um+/+tBc0H99wd0+Ugr1fMNMoP
+0YLTsRE/1OPwekWPxM8aKlrgq77yWk00B92PYFV9o4miJoR+2PVP/DUF5PsX
+iUxNxWhBluDkwOIiOhovevEu9tIDbaCV7qqv4tGQC/tcL7Z7rw2Hi65kFnLw
++s/VH02KArVhps2Jp/cr7/w9nhPf8OWJKh0IFDRRVwhTUTz9wYor777oQKr2
+ciLxLA3FuyWq7BexVAcO6uj5+vaS0XlteOxOt/fSBeWolTYWBirIRybFzW2i
+deBwwO2X2S0sNN/a9vumaA89OEQ37RmZUkbu0nw74d1JffiWpzp0IgCPmeTj
+h+K8DKA/5lGhbBobuYQpsWp1mwHcgANhxsV4/ZZd021KRw2AN/jZvTZFCcUr
+eEj4aSwwAKupBy3TTznIT1xqS1xxzwC8Tnao5qhx0PzORrgbSDCE0Rub4oty
+uchTpplPEkINwf52joaZHRftt0qOmuRmZwipR85yz9vg+yn9XCU1UGcIkymp
+mju+Y18V33xJzNYQspZU/ZhdwULz2YLO8UgXI7BqkNGZLcfxsnRDAlc7GkFp
+RmXfvQwWel7800kyE7/up/Gq5nbHQkXkCU5i7jqbDeG6XlKtCUsRjROb0gNC
+hwxheHnK4k+3mMg9ScJ8QbshgPGK1P5XCuj75N6xNfuaxxLYbWexfI8ZG/m2
+28s6xg11obekOn3AgoPH7K+UEg09YGabDzmVYDf8NPXitaEe5A4vUo1eg33j
+leYhzz5dcA1Mafee46B+8NIdD/0+7yeD9OrQ3F5lGvIib9+30mwK6C4vvRXg
+TkP94AbLy7SpNUzQYXoHDhKUkCtNXDn3hy8TXi++wBorV0L94rb30fa0BDKM
+zm1L+7BFFXneVneL7B4S0FNZ1o07VVE/+budgBBXMscPzzFILUjmIo+90vrH
+4vzP/I8KL0KPmeD1V0NXXJd4MsvXePSlXXMVXl9X2tIwHzLEd7E+8k7WEbs6
+Te9qQ+8Mv/iMx4DuJ3w959bnb3nZg/xXDQ3WmrZqyGOJvLMxnU/5a95Hnnr9
+UBW5/qi0fop5D18x6ntIGl0N7ef/+m5BU+dP997gIgeiaKa8VCXf1XvP9+Ep
+7EI7KFIZu1P4az3lNwX9xYX/Aq1p5A0=
+         "], 0.08942735681306904]}, 
        {Hue[0.6, 0.2, 0.8], EdgeForm[{GrayLevel[0], Opacity[0.7]}], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.025842944856429, 5.45412768075216}, 0.09160670148647594],
-          
+          DiskBox[{4.322272557054233, 7.145729031014684}, 0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.620120495417171, 6.39478642923024}, 0.09160670148647594],
-          
+          DiskBox[{3.4415227163950988, 7.422455214068544}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.047640351988009, 6.910551753866362}, 0.09160670148647594],
+          DiskBox[{2.913742202710845, 7.715866914496713}, 0.08942735681306904],
           "\"H1\""],
          Annotation[#, 
           HoldForm["H1"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.9455198587854925, 7.048658085235333}, 
-           0.09160670148647594],
+          DiskBox[{2.8728539085033566, 7.5250493338415705}, 
+           0.08942735681306904],
           "\"An exhibit of Markdown\""],
          Annotation[#, 
           HoldForm["An exhibit of Markdown"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.309328148249578, 7.164098345251812}, 0.09160670148647594],
+          DiskBox[{2.495475759324759, 6.476700320186519}, 0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.15395278732761, 7.86108728091709}, 0.09160670148647594],
+          DiskBox[{1.774655195681639, 6.2855940507457735}, 
+           0.08942735681306904],
           "\"This note demonstrates some of what\""],
          Annotation[#, 
           HoldForm["This note demonstrates some of what"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.705718890068413, 8.439897629767932}, 0.09160670148647594],
+          DiskBox[{1.092198483891612, 6.019459900549288}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.537690575042592, 9.121431359113807}, 0.09160670148647594],
+          DiskBox[{0.4543865818173547, 5.642844715004759}, 
+           0.08942735681306904],
           "Hyperlink"],
          Annotation[#, 
           HoldForm[Hyperlink], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.256453229541996, 8.996279540296081}, 0.09160670148647594],
+          DiskBox[{0.37617804728003, 5.782219855878961}, 0.08942735681306904],
+          
           "\"Markdown\""],
          Annotation[#, 
           HoldForm["Markdown"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.3854327919374265, 9.092263004507108}, 
-           0.09160670148647594],
+          DiskBox[{0.35149203238386395, 5.951384794462146}, 
+           0.08942735681306904],
           "\" http://daringfireball.net/projects/markdown/\""],
          Annotation[#, 
           HoldForm[" http://daringfireball.net/projects/markdown/"], 
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.9971228981781906, 7.800197312372898}, 
-           0.09160670148647594],
+          DiskBox[{1.855368447948944, 6.112949664091323}, 0.08942735681306904],
           "\" is capable of doing.\""],
          Annotation[#, 
           HoldForm[" is capable of doing."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.418838207707254, 4.622856706376563}, 0.09160670148647594],
+          DiskBox[{3.4521948722375977, 6.444248079712046}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.007037232205731, 4.18575228065161}, 0.09160670148647594],
-          
+          DiskBox[{2.8438348519242536, 6.078576914869706}, 
+           0.08942735681306904],
           "Italic"],
          Annotation[#, 
           HoldForm[Italic], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.059061186382838, 4.042863403439318}, 0.09160670148647594],
+          DiskBox[{2.985134323119963, 5.952933097902237}, 0.08942735681306904],
           
           "\"Note: Feel free to play with this page. Unlike regular notes, \
 this doesn't automatically save itself.\""],
@@ -2553,25 +2762,24 @@ this doesn't automatically save itself.\""],
 doesn't automatically save itself."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.217665473400974, 4.507318416776434}, 0.09160670148647594],
+          DiskBox[{3.639457733550203, 6.208639435143806}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.410061410022182, 3.9065706337331427}, 
-           0.09160670148647594],
+          DiskBox[{3.2712911020522615, 5.56496378098758}, 0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.237737723789605, 3.930413402002688}, 0.09160670148647594],
+          DiskBox[{3.155004781158571, 5.695928590816965}, 0.08942735681306904],
           "\"Basic formatting\""],
          Annotation[#, 
           HoldForm["Basic formatting"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.087624459479368, 5.816887697174768}, 0.09160670148647594],
+          DiskBox[{4.348997133322051, 6.763087900409217}, 0.08942735681306904],
           
           "\"Write Paragraphs like so. A paragraph is the basic block of \
 Markdown. A paragraph is what text will turn into when there is no reason it \
@@ -2583,340 +2791,348 @@ Markdown. A paragraph is what text will turn into when there is no reason it \
 should become anything else."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.1720250170747235, 4.2528618420698034}, 
-           0.09160670148647594],
+          DiskBox[{2.6995585044344406, 5.562094706070175}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.73621615184561, 3.7277426065087083}, 0.09160670148647594],
+          DiskBox[{2.212551486909623, 5.047773781864759}, 0.08942735681306904],
           "\"Blank lines separate paragraphs. Markdown supports \""],
          Annotation[#, 
           HoldForm["Blank lines separate paragraphs. Markdown supports "], 
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.0330766167353165, 3.7648746847406613}, 
-           0.09160670148647594],
+          DiskBox[{1.919348405394584, 4.576921393769913}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{2.3363699363271175, 3.571103908394422}, 
-           0.09160670148647594],
+          DiskBox[{1.538909835608722, 3.9576360158325103}, 
+           0.08942735681306904],
           "Italic"],
          Annotation[#, 
           HoldForm[Italic], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{2.411014001849395, 3.402308691786019}, 0.09160670148647594],
+          DiskBox[{1.3900742948205043, 4.066637111696745}, 
+           0.08942735681306904],
           "\"italic\""],
          Annotation[#, 
           HoldForm["italic"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.524026469069936, 4.01300737449091}, 0.09160670148647594],
-          
+          DiskBox[{2.366014655351148, 4.941630905688816}, 0.08942735681306904],
           "\" and \""],
          Annotation[#, 
           HoldForm[" and "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.234944154112604, 3.4692852202405864}, 
-           0.09160670148647594],
+          DiskBox[{1.6689378430455895, 4.8312726477848615}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{2.6255572353243526, 3.07905666025258}, 0.09160670148647594],
+          DiskBox[{1.0198358560868046, 4.484623147831732}, 
+           0.08942735681306904],
           "Bold"],
          Annotation[#, 
           HoldForm[Bold], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{2.7593057304499373, 2.953252983110071}, 
-           0.09160670148647594],
+          DiskBox[{1.122928359783911, 4.333743829663209}, 0.08942735681306904],
           "\"bold\""],
          Annotation[#, 
           HoldForm["bold"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.5964880691391286, 3.8385706422908727}, 
-           0.09160670148647594],
+          DiskBox[{2.0926785902461393, 5.201132027663646}, 
+           0.08942735681306904],
           "\" formatting.\""],
          Annotation[#, 
           HoldForm[" formatting."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.423593741625793, 6.952234926818399}, 0.09160670148647594],
+          DiskBox[{4.326081966797361, 4.9524992447351295}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.966628031087262, 7.518422028749669}, 0.09160670148647594],
+          DiskBox[{4.252740093370017, 4.213956598384672}, 0.08942735681306904],
           "\"Lines can have nested styling as well, like \""],
          Annotation[#, 
           HoldForm["Lines can have nested styling as well, like "], 
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.088989322181506, 8.178058936978301}, 0.09160670148647594],
+          DiskBox[{4.31196516753247, 3.183257565598525}, 0.08942735681306904],
+          
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{2.591310149590276, 8.624813066290109}, 0.09160670148647594],
+          DiskBox[{4.342688568619282, 2.5324655164778926}, 
+           0.08942735681306904],
           "Italic"],
          Annotation[#, 
           HoldForm[Italic], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{1.965553244729457, 9.22293253870114}, 0.09160670148647594],
-          
+          DiskBox[{4.267706236590673, 1.6840961621418131}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{1.5928989040370265, 9.72365611796635}, 0.09160670148647594],
+          DiskBox[{4.147250690160259, 1.0860252216791535}, 
+           0.08942735681306904],
           "\"a \""],
          Annotation[#, 
           HoldForm["a "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{1.16187077202025, 9.96434819717191}, 0.09160670148647594],
+          DiskBox[{4.209066272404006, 0.6165290163642503}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{0.6329123759091431, 10.314607842120111}, 
-           0.09160670148647594],
+          DiskBox[{4.066446590532573, 0.011878609290186581}, 
+           0.08942735681306904],
           "Bold"],
          Annotation[#, 
           HoldForm[Bold], "Tooltip"]& ], 
         TagBox[
-         TooltipBox[
-          DiskBox[{0.7724489137794306, 10.464603479398331}, 
-           0.09160670148647594],
+         TooltipBox[DiskBox[{4.276035371956734, 0.}, 0.08942735681306904],
           "\"bold\""],
          Annotation[#, 
           HoldForm["bold"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{1.4443835516223178, 9.565798109120522}, 
-           0.09160670148647594],
+          DiskBox[{4.376513416978742, 1.0829856290860729}, 
+           0.08942735681306904],
           "\" in an italic\""],
          Annotation[#, 
           HoldForm[" in an italic"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.8343298034893394, 7.387926680338243}, 
-           0.09160670148647594],
+          DiskBox[{4.454618162928325, 4.225210349175629}, 0.08942735681306904],
           "\".\""],
          Annotation[#, 
           HoldForm["."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.239854972995111, 5.192180071356066}, 0.09160670148647594],
+          DiskBox[{4.332325457082727, 6.110358683418494}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.972822651840091, 4.940095327728179}, 0.09160670148647594],
+          DiskBox[{4.414388630168453, 5.476746142315046}, 0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{8.02734202939946, 5.095842114160234}, 0.09160670148647594],
-          
+          DiskBox[{4.245249055933302, 5.455207759270213}, 0.08942735681306904],
           "\"Lists\""],
          Annotation[#, 
           HoldForm["Lists"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.997948528865305, 5.356548696386825}, 0.09160670148647594],
+          DiskBox[{5.424253613793371, 6.5927895073853096}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.331375940872876, 5.249079503051126}, 0.09160670148647594],
+          DiskBox[{6.075433567533172, 6.187659595124795}, 0.08942735681306904],
           "\"H3\""],
          Annotation[#, 
           HoldForm["H3"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.360794830174032, 5.395971442323729}, 0.09160670148647594],
+          DiskBox[{6.167501003029708, 6.3422901140175725}, 
+           0.08942735681306904],
           "\"Ordered list\""],
          Annotation[#, 
           HoldForm["Ordered list"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.522349198315789, 5.092130173445839}, 0.09160670148647594],
+          DiskBox[{3.3907403029948937, 8.448770763245767}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.827473185936216, 5.013646054652242}, 0.09160670148647594],
+          DiskBox[{3.0350394178990827, 9.097264104758596}, 
+           0.08942735681306904],
           "\"ItemNumbered\""],
          Annotation[#, 
           HoldForm["ItemNumbered"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.5109783053533383, 4.896238530469417}, 
-           0.09160670148647594],
+          DiskBox[{2.7870709117103374, 9.325318067503714}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{2.798710928749685, 4.772779167784242}, 0.09160670148647594],
+          DiskBox[{2.3748561795999263, 9.920909639214065}, 
+           0.08942735681306904],
           "1"],
          Annotation[#, 
           HoldForm[1], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.8823172759662503, 4.812977180149758}, 
-           0.09160670148647594],
+          DiskBox[{2.8603885479966746, 8.974885283878603}, 
+           0.08942735681306904],
           "\"Item 1\""],
          Annotation[#, 
           HoldForm["Item 1"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.209060810568541, 6.76066785877665}, 0.09160670148647594],
-          
+          DiskBox[{4.969187560830891, 5.636798419102588}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.96637189414541, 7.3881080946805895}, 0.09160670148647594],
+          DiskBox[{5.1691795814593995, 4.899223011515423}, 
+           0.08942735681306904],
           "\"ItemNumbered\""],
          Annotation[#, 
           HoldForm["ItemNumbered"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.618443273001937, 7.593109239964694}, 0.09160670148647594],
+          DiskBox[{5.411882412875789, 4.659879441940179}, 0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.199012940601848, 8.18012334583936}, 0.09160670148647594],
-          
+          DiskBox[{5.710088064615022, 3.9953405202961614}, 
+           0.08942735681306904],
           "2"],
          Annotation[#, 
           HoldForm[2], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.793263224626617, 7.299093330414339}, 0.09160670148647594],
+          DiskBox[{5.363399804353503, 4.973496142629077}, 0.08942735681306904],
           "\"A second item\""],
          Annotation[#, 
           HoldForm["A second item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.679406165739543, 6.224464190798201}, 0.09160670148647594],
+          DiskBox[{2.7479683424124506, 7.381171535460188}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.139406587063361, 6.658042038174172}, 0.09160670148647594],
+          DiskBox[{2.050532355046797, 7.435798762921207}, 0.08942735681306904],
           "\"ItemNumbered\""],
          Annotation[#, 
           HoldForm["ItemNumbered"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.7587340739859285, 6.732435338926631}, 
-           0.09160670148647594],
+          DiskBox[{1.6960483467744192, 7.5229585665364755}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.111129361833184, 7.083313261067858}, 0.09160670148647594],
+          DiskBox[{0.9554745472795547, 7.598706334378263}, 
+           0.08942735681306904],
           "3"],
          Annotation[#, 
           HoldForm[3], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.033355988556261, 6.497721892097402}, 0.09160670148647594],
+          DiskBox[{2.0774973973992052, 7.629629337796121}, 
+           0.08942735681306904],
           "\"Number 3\""],
          Annotation[#, 
           HoldForm["Number 3"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.493213678895998, 5.78272863743856}, 0.09160670148647594],
+          DiskBox[{2.740231579328146, 7.00742036089381}, 0.08942735681306904],
           
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.815871851328913, 6.014292520622623}, 0.09160670148647594],
+          DiskBox[{2.031490248654433, 6.831789862753861}, 0.08942735681306904],
           "\"ItemNumbered\""],
          Annotation[#, 
           HoldForm["ItemNumbered"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.4809272727626777, 6.069174661598465}, 
-           0.09160670148647594],
+          DiskBox[{1.664294742116616, 6.929485652057409}, 0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{2.7802109449244554, 6.265957371712964}, 
-           0.09160670148647594],
+          DiskBox[{0.9125712573053235, 6.874875331141788}, 
+           0.08942735681306904],
           "4"],
          Annotation[#, 
           HoldForm[4], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.776818648549834, 5.842942307301692}, 0.09160670148647594],
+          DiskBox[{2.0169376009685127, 7.033948561131338}, 
+           0.08942735681306904],
           "\"\:2163\""],
          Annotation[#, 
           HoldForm["\:2163"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.433027851105744, 4.015470066799621}, 0.09160670148647594],
+          DiskBox[{4.909900801628416, 9.112189256592476}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.978664158073902, 3.5237320145488114}, 
-           0.09160670148647594],
+          DiskBox[{5.160668328557224, 9.831468127584616}, 0.08942735681306904],
           "Italic"],
          Annotation[#, 
           HoldForm[Italic], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{8.597541401500989, 2.776777355042217}, 0.09160670148647594],
+          DiskBox[{5.395119568220605, 10.767930974265287}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{9.131394729760649, 2.404410371351595}, 0.09160670148647594],
+          DiskBox[{5.694889451802169, 11.359010997820588}, 
+           0.08942735681306904],
           "\"Note: the fourth item uses the Unicode character for\""],
          Annotation[#, 
           HoldForm["Note: the fourth item uses the Unicode character for"], 
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{9.435228817556151, 1.8115489214475708}, 
-           0.09160670148647594],
+          DiskBox[{5.732185897414394, 12.013236991687158}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{9.7069355517424, 1.2236303777390072}, 0.09160670148647594],
-          
+          DiskBox[{5.7259017606247795, 12.655313749186174}, 
+           0.08942735681306904],
           "Hyperlink"],
          Annotation[#, 
           HoldForm[Hyperlink], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{9.870208958575883, 1.3073438006381677}, 
-           0.09160670148647594],
+          DiskBox[{6.05668194934054, 12.569151620643897}, 0.08942735681306904],
           "\"Roman numeral four\""],
          Annotation[#, 
           HoldForm["Roman numeral four"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{9.965340211894052, 1.4591930925431842}, 
-           0.09160670148647594],
+          DiskBox[{5.905615591177456, 12.669716029613433}, 
+           0.08942735681306904],
           "\" http://www.fileformat.info/info/unicode/char/2163/index.htm\""],
          
          Annotation[#, 
@@ -2925,157 +3141,185 @@ should become anything else."], "Tooltip"]& ],
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{8.986539465385272, 2.2528971268653026}, 
-           0.09160670148647594],
+          DiskBox[{5.489104005623858, 11.424579552148497}, 
+           0.08942735681306904],
           "\".\""],
          Annotation[#, 
           HoldForm["."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.615933800958961, 4.473311445782341}, 0.09160670148647594],
+          DiskBox[{5.109959495463368, 6.221127014196542}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.927603035250393, 3.8571277061390203}, 
-           0.09160670148647594],
+          DiskBox[{5.53530615040319, 5.593404855589101}, 0.08942735681306904],
+          
           "\"H3\""],
          Annotation[#, 
           HoldForm["H3"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.075564380638274, 3.8759893218982064}, 
-           0.09160670148647594],
+          DiskBox[{5.678839158414441, 5.703299460445507}, 0.08942735681306904],
           "\"Unordered list\""],
          Annotation[#, 
           HoldForm["Unordered list"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.06543860255713, 5.413778805468858}, 0.09160670148647594],
-          
+          DiskBox[{4.045367329376424, 8.339502441474657}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.74068644626582, 5.2979311847782995}, 0.09160670148647594],
+          DiskBox[{3.9449455378936147, 9.110106669564992}, 
+           0.08942735681306904],
           "\"Item\""],
          Annotation[#, 
           HoldForm["Item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.715583534040036, 5.487061246091437}, 0.09160670148647594],
-          "\"An item\""],
+          DiskBox[{3.7941784658655893, 9.048014723523783}, 
+           0.08942735681306904],
+          RowBox[{"\[LeftAssociation]", 
+            RowBox[{
+              RowBox[{"\"IndentationLevel\"", "\[Rule]", "0"}], ",", 
+              RowBox[{"\"IndentationType\"", "\[Rule]", "None"}], ",", 
+              RowBox[{"\"Content\"", "\[Rule]", "\"An item\""}]}], 
+            "\[RightAssociation]"}]],
          Annotation[#, 
-          HoldForm["An item"], "Tooltip"]& ], 
+          HoldForm[
+           Association[
+           "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+            "An item"]], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.849029310841057, 4.359503536025632}, 0.09160670148647594],
+          DiskBox[{3.922096382994882, 6.241235442709006}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.823237514260362, 3.6903309537644127}, 
-           0.09160670148647594],
+          DiskBox[{3.763032628076757, 5.6393711917602705}, 
+           0.08942735681306904],
           "\"Item\""],
          Annotation[#, 
           HoldForm["Item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.641637432626458, 3.6579301317433037}, 
-           0.09160670148647594],
-          "\"Another item\""],
+          DiskBox[{3.5710698418946154, 5.724645914195707}, 
+           0.08942735681306904],
+          RowBox[{"\[LeftAssociation]", 
+            RowBox[{
+              RowBox[{"\"IndentationLevel\"", "\[Rule]", "0"}], ",", 
+              RowBox[{"\"IndentationType\"", "\[Rule]", "None"}], ",", 
+              RowBox[{"\"Content\"", "\[Rule]", "\"Another item\""}]}], 
+            "\[RightAssociation]"}]],
          Annotation[#, 
-          HoldForm["Another item"], "Tooltip"]& ], 
+          HoldForm[
+           Association[
+           "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+            "Another item"]], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.5571233390070285, 6.154063590308478}, 
-           0.09160670148647594],
+          DiskBox[{4.270452107341244, 8.246487054173635}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.151021902980803, 6.5289222434417615}, 
-           0.09160670148647594],
+          DiskBox[{4.163042313770966, 8.912040939702731}, 0.08942735681306904],
           "\"Item\""],
          Annotation[#, 
           HoldForm["Item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.346789862844067, 6.626879774536471}, 0.09160670148647594],
-          "\"Yet another item\""],
+          DiskBox[{4.3057236754948125, 8.973631835511464}, 
+           0.08942735681306904],
+          RowBox[{"\[LeftAssociation]", 
+            RowBox[{
+              RowBox[{"\"IndentationLevel\"", "\[Rule]", "0"}], ",", 
+              RowBox[{"\"IndentationType\"", "\[Rule]", "None"}], ",", 
+              RowBox[{"\"Content\"", "\[Rule]", "\"Yet another item\""}]}], 
+            "\[RightAssociation]"}]],
          Annotation[#, 
-          HoldForm["Yet another item"], "Tooltip"]& ], 
+          HoldForm[
+           Association[
+           "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+            "Yet another item"]], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.0537379596016585, 5.786966525537375}, 
-           0.09160670148647594],
+          DiskBox[{3.607847979823529, 8.021437859376613}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.491960232444432, 6.070238121005654}, 0.09160670148647594],
+          DiskBox[{3.228041396219332, 8.625091539248817}, 0.08942735681306904],
           "\"Item\""],
          Annotation[#, 
           HoldForm["Item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.389669619025975, 5.930201562734756}, 0.09160670148647594],
-          "\"And there's more...\""],
+          DiskBox[{3.099939190364843, 8.502662288592505}, 0.08942735681306904],
+          RowBox[{"\[LeftAssociation]", 
+            RowBox[{
+              RowBox[{"\"IndentationLevel\"", "\[Rule]", "0"}], ",", 
+              RowBox[{"\"IndentationType\"", "\[Rule]", "None"}], ",", 
+              RowBox[{"\"Content\"", "\[Rule]", "\"And there's more...\""}]}],
+             "\[RightAssociation]"}]],
          Annotation[#, 
-          HoldForm["And there's more..."], "Tooltip"]& ], 
+          HoldForm[
+           Association[
+           "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+            "And there's more..."]], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.257186070701576, 5.517440366500037}, 0.09160670148647594],
+          DiskBox[{3.2599401638927583, 6.974743152909733}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.994623163482024, 5.6375854961335}, 0.09160670148647594],
+          DiskBox[{2.6254071462759123, 6.760178134156456}, 
+           0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{8.049909719169975, 5.470411969452256}, 0.09160670148647594],
+          DiskBox[{2.557272558251657, 6.964310501932172}, 0.08942735681306904],
           "\"Paragraph modifiers\""],
          Annotation[#, 
           HoldForm["Paragraph modifiers"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.898185377247101, 6.146419181076857}, 0.09160670148647594],
+          DiskBox[{3.2747651604096153, 7.596825211265023}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.3993578021551905, 6.627939542289806}, 
-           0.09160670148647594],
+          DiskBox[{2.668189506022804, 7.955487896420319}, 0.08942735681306904],
           "\"H3\""],
          Annotation[#, 
           HoldForm["H3"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.51631171023541, 6.522590244123406}, 0.09160670148647594],
-          
+          DiskBox[{2.583462420235433, 7.808002221840923}, 0.08942735681306904],
           "\"Code block\""],
          Annotation[#, 
           HoldForm["Code block"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.2102487522352385, 4.736922602685533}, 
-           0.09160670148647594],
+          DiskBox[{5.042231721168063, 8.184686961155855}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.6603437201814675, 4.3611623620353965}, 
-           0.09160670148647594],
+          DiskBox[{5.572692681184848, 8.813553399906226}, 0.08942735681306904],
           "\"CodeBlock\""],
          Annotation[#, 
           HoldForm["CodeBlock"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.7411183068290494, 4.224814765967233}, 
-           0.09160670148647594],
+          DiskBox[{5.426848409813007, 8.856098929027517}, 0.08942735681306904],
           RowBox[{"\[LeftAssociation]", 
             RowBox[{
               RowBox[{"\"Language\"", "\[Rule]", "\"None\""}], ",", 
@@ -3093,75 +3337,74 @@ clarity of plain text content. As you can see, it uses a fixed-width font."]],
            "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.611962213230936, 3.8182129122348067}, 
-           0.09160670148647594],
+          DiskBox[{5.741005889977899, 6.034741487299989}, 0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.350848663952627, 3.1495691107970587}, 
-           0.09160670148647594],
+          DiskBox[{6.286407695295645, 5.503119767811316}, 0.08942735681306904],
           "\"You can also make \""],
          Annotation[#, 
           HoldForm["You can also make "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.318007712017134, 2.641017384167273}, 0.09160670148647594],
+          DiskBox[{6.697581320511363, 5.230082325835171}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.2432043913785895, 1.945970387520406}, 
-           0.09160670148647594],
+          DiskBox[{7.293243515642263, 4.846896394297839}, 0.08942735681306904],
           "\"InlineCode\""],
          Annotation[#, 
           HoldForm["InlineCode"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.057096389313495, 1.990909950918934}, 0.09160670148647594],
+          DiskBox[{7.165356397718098, 4.691343148158978}, 0.08942735681306904],
           "\"inline code\""],
          Annotation[#, 
           HoldForm["inline code"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.551913660271499, 3.104861819025453}, 0.09160670148647594],
+          DiskBox[{6.4131080855371305, 5.676692322511208}, 
+           0.08942735681306904],
           "\" to add insert code block formatting anywhere.\""],
          Annotation[#, 
           HoldForm[" to add insert code block formatting anywhere."], 
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.095585952140754, 6.537686033324353}, 0.09160670148647594],
+          DiskBox[{4.826905082600664, 6.10419862297359}, 0.08942735681306904],
+          
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.233371393212712, 7.223041220309451}, 0.09160670148647594],
+          DiskBox[{5.229422379189021, 5.508456945098216}, 0.08942735681306904],
           "\"H3\""],
          Annotation[#, 
           HoldForm["H3"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.080129667363797, 7.212688255308891}, 0.09160670148647594],
+          DiskBox[{5.078980191363078, 5.4060193131329095}, 
+           0.08942735681306904],
           "\"Quote\""],
          Annotation[#, 
           HoldForm["Quote"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.343741692368368, 6.6300053505729775}, 
-           0.09160670148647594],
+          DiskBox[{5.308751819544236, 8.028699760445818}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.456766553817349, 7.386241927980094}, 0.09160670148647594],
+          DiskBox[{5.86228112923361, 8.645822082669358}, 0.08942735681306904],
+          
           "\"BlockQuote\""],
          Annotation[#, 
           HoldForm["BlockQuote"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.631210878036696, 7.3332681350842215}, 
-           0.09160670148647594],
+          DiskBox[{5.967322104906632, 8.516608476532362}, 0.08942735681306904],
           
           "\"Here is a quote. What this is should be self explanatory. Quotes \
 are automatically indented when they are used.\""],
@@ -3171,26 +3414,26 @@ are automatically indented when they are used.\""],
 are automatically indented when they are used."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.723509592503691, 4.67229081364555}, 0.09160670148647594],
-          
+          DiskBox[{3.4720398989750643, 6.6832351510939345}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.102058546793876, 4.145219283335042}, 0.09160670148647594],
+          DiskBox[{2.889156747786964, 6.452128218512438}, 0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.245169100850946, 4.242158557547712}, 0.09160670148647594],
+          DiskBox[{2.9998288407296934, 6.307990704384299}, 
+           0.08942735681306904],
           "\"Headings\""],
          Annotation[#, 
           HoldForm["Headings"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.2934231302307175, 5.724674118232313}, 
-           0.09160670148647594],
+          DiskBox[{3.995353513375007, 7.293319728698828}, 0.08942735681306904],
           
           "\"Markdown supports six levels of headings; corresponding with the \
 six levels of HTML headings. You've probably noticed them already in the \
@@ -3202,120 +3445,125 @@ six levels of HTML headings. You've probably noticed them already in the \
 page. Each level down uses one more hash character."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.8010591091659376, 5.534760625825223}, 
-           0.09160670148647594],
+          DiskBox[{3.509061038585354, 9.203122133926495}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.060820191213838, 5.56808953444564}, 0.09160670148647594],
-          
+          DiskBox[{3.3166971252621926, 9.923778679944483}, 
+           0.08942735681306904],
           "\"H3\""],
          Annotation[#, 
           HoldForm["H3"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{1.8293167274965771, 5.6248559935608}, 0.09160670148647594],
-          
+          DiskBox[{2.755383994402577, 10.984787985369946}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{1.202482968494114, 5.773833659227151}, 0.09160670148647594],
+          DiskBox[{2.621663231500285, 11.603261820503189}, 
+           0.08942735681306904],
           "\"Headings \""],
          Annotation[#, 
           HoldForm["Headings "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{0.6945252035394445, 5.8490774581880185}, 
-           0.09160670148647594],
+          DiskBox[{2.148866570255555, 11.950121466627504}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{0.014295399446109691, 5.887684261425428}, 
-           0.09160670148647594],
+          DiskBox[{1.7164653885365242, 12.474181430937636}, 
+           0.08942735681306904],
           "Italic"],
          Annotation[#, 
           HoldForm[Italic], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{0.059700561610212866, 6.073238974540501}, 
-           0.09160670148647594],
+          DiskBox[{1.8907176844103715, 12.551490346154528}, 
+           0.08942735681306904],
           "\"can\""],
          Annotation[#, 
           HoldForm["can"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{1.1901426461805018, 5.551879262213013}, 
-           0.09160670148647594],
+          DiskBox[{2.4052558951640712, 11.514973002930258}, 
+           0.08942735681306904],
           "\" also contain \""],
          Annotation[#, 
           HoldForm[" also contain "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{0.681197667929708, 5.489863490976607}, 0.09160670148647594],
+          DiskBox[{2.4765177815597115, 12.075203945942544}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{0.02964535689637149, 5.317257382264162}, 
-           0.09160670148647594],
+          DiskBox[{2.406005064441298, 12.723755324774446}, 
+           0.08942735681306904],
           "Bold"],
          Annotation[#, 
           HoldForm[Bold], "Tooltip"]& ], 
         TagBox[
-         TooltipBox[DiskBox[{0., 5.501082309715722}, 0.09160670148647594],
+         TooltipBox[
+          DiskBox[{2.2232694652251648, 12.68106400023689}, 
+           0.08942735681306904],
           "\"formatting\""],
          Annotation[#, 
           HoldForm["formatting"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.07379218884841, 3.647755266660891}, 0.09160670148647594],
-          
+          DiskBox[{3.6279313604037347, 5.428777021161971}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.141809066829763, 2.933795477325431}, 0.09160670148647594],
+          DiskBox[{3.3714309400110354, 4.737160466491691}, 
+           0.08942735681306904],
           "\"H3\""],
          Annotation[#, 
           HoldForm["H3"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.090948680076483, 2.140360573281638}, 0.09160670148647594],
+          DiskBox[{3.0574292623526445, 4.0085969109425985}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.114007780658365, 1.4705286736154748}, 
-           0.09160670148647594],
+          DiskBox[{2.830162890218578, 3.3653574215263276}, 
+           0.08942735681306904],
           "\"They can even contain \""],
          Annotation[#, 
           HoldForm["They can even contain "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.0775408247320755, 0.9746873641037768}, 
-           0.09160670148647594],
+          DiskBox[{2.5821295452607314, 2.9343749416578735}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.969331198776891, 0.30553010356209676}, 
-           0.09160670148647594],
+          DiskBox[{2.2103988850361054, 2.3599506351723907}, 
+           0.08942735681306904],
           "\"InlineCode\""],
          Annotation[#, 
           HoldForm["InlineCode"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.163069341178209, 0.3034345863820116}, 
-           0.09160670148647594],
+          DiskBox[{2.394023211641699, 2.2821630572749454}, 
+           0.08942735681306904],
           "\"inline code\""],
          Annotation[#, 
           HoldForm["inline code"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.781407424815933, 5.638484260634636}, 0.09160670148647594],
+          DiskBox[{4.634107266833624, 7.340939615986094}, 0.08942735681306904],
           
           "\"Of course, demonstrating what headings look like messes up the \
 structure of the page.\""],
@@ -3325,7 +3573,8 @@ structure of the page.\""],
 structure of the page."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.219248419207682, 5.064931003278603}, 0.09160670148647594],
+          DiskBox[{4.093824215344732, 6.8277103361361196}, 
+           0.08942735681306904],
           
           "\"I don't recommend using more than three or four levels of \
 headings here, because, when you're smallest heading isn't too small, and \
@@ -3341,63 +3590,68 @@ larger and more important, there aren't any other sizes to choose from."],
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.232209150836324, 5.7654683332962255}, 
-           0.09160670148647594],
+          DiskBox[{3.409597958975841, 7.835387784538868}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.9971744577115365, 5.879214578624034}, 
-           0.09160670148647594],
+          DiskBox[{2.7797315880465723, 8.21169473421452}, 0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.974236666807245, 6.030581425642488}, 0.09160670148647594],
+          DiskBox[{2.9112363223446014, 8.301934271887658}, 
+           0.08942735681306904],
           "\"LaTex\""],
          Annotation[#, 
           HoldForm["LaTex"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.974117025218812, 5.069626731118244}, 0.09160670148647594],
+          DiskBox[{4.414953768723779, 7.487321231034443}, 0.08942735681306904],
           "\"LaTex is also supported:\""],
          Annotation[#, 
           HoldForm["LaTex is also supported:"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.263551825951227, 6.102651068590877}, 0.09160670148647594],
+          DiskBox[{5.586255780554853, 7.323753507608947}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.742286739591533, 6.448279829605884}, 0.09160670148647594],
+          DiskBox[{6.3793538798213865, 7.338420790193555}, 
+           0.08942735681306904],
           "\"Item\""],
          Annotation[#, 
           HoldForm["Item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.841396342286892, 6.599180000876084}, 0.09160670148647594],
-          "\"inline\""],
+          DiskBox[{6.362430844788163, 7.527914840261621}, 0.08942735681306904],
+          RowBox[{"\[LeftAssociation]", 
+            RowBox[{
+              RowBox[{"\"IndentationLevel\"", "\[Rule]", "0"}], ",", 
+              RowBox[{"\"IndentationType\"", "\[Rule]", "None"}], ",", 
+              RowBox[{"\"Content\"", "\[Rule]", "\"inline\""}]}], 
+            "\[RightAssociation]"}]],
          Annotation[#, 
-          HoldForm["inline"], "Tooltip"]& ], 
+          HoldForm[
+           Association[
+           "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+            "inline"]], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.34350325394518, 6.394423044303554}, 0.09160670148647594],
-          
+          DiskBox[{5.509966697539656, 7.677758607562568}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.4346765906252195, 7.007356911679618}, 
-           0.09160670148647594],
-          "\"LaTex\""],
+          DiskBox[{6.210898434993034, 8.103445667993224}, 0.08942735681306904],
+          "\"LaTeX\""],
          Annotation[#, 
-          HoldForm["LaTex"], "Tooltip"]& ], 
+          HoldForm["LaTeX"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.64911132722085, 6.973683281586607}, 0.09160670148647594],
-          
+          DiskBox[{6.278213051772651, 7.921892327998132}, 0.08942735681306904],
           RowBox[{"\[LeftAssociation]", 
             RowBox[{
               RowBox[{"\"Type\"", "\[Rule]", "\"Inline\""}], ",", 
@@ -3409,19 +3663,21 @@ larger and more important, there aren't any other sizes to choose from."],
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.972370755368974, 5.135832458317468}, 0.09160670148647594],
+          DiskBox[{5.018154581903339, 6.4487150727933065}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.562474835256111, 4.852579470363673}, 0.09160670148647594],
-          "\"LaTex\""],
+          DiskBox[{5.5246881302518025, 6.108833475654644}, 
+           0.08942735681306904],
+          "\"LaTeX\""],
          Annotation[#, 
-          HoldForm["LaTex"], "Tooltip"]& ], 
+          HoldForm["LaTeX"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.595599489492614, 5.0392863082201105}, 
-           0.09160670148647594],
+          DiskBox[{5.4047476795985085, 5.925859591337826}, 
+           0.08942735681306904],
           RowBox[{"\[LeftAssociation]", 
             RowBox[{
               RowBox[{"\"Type\"", "\[Rule]", "\"Inline\""}], ",", 
@@ -3433,38 +3689,44 @@ larger and more important, there aren't any other sizes to choose from."],
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.985757512318082, 5.855048500471524}, 0.09160670148647594],
+          DiskBox[{5.291137329090638, 6.758235621853336}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.56272934412745, 6.190702907291495}, 0.09160670148647594],
+          DiskBox[{5.85578284627352, 6.432511087638551}, 0.08942735681306904],
           
           "\"Item\""],
          Annotation[#, 
           HoldForm["Item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.635306387905126, 6.022594302716439}, 0.09160670148647594],
-          "\"presented\""],
+          DiskBox[{5.960712335553722, 6.589666849392204}, 0.08942735681306904],
+          RowBox[{"\[LeftAssociation]", 
+            RowBox[{
+              RowBox[{"\"IndentationLevel\"", "\[Rule]", "0"}], ",", 
+              RowBox[{"\"IndentationType\"", "\[Rule]", "None"}], ",", 
+              RowBox[{"\"Content\"", "\[Rule]", "\"presented\""}]}], 
+            "\[RightAssociation]"}]],
          Annotation[#, 
-          HoldForm["presented"], "Tooltip"]& ], 
+          HoldForm[
+           Association[
+           "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> 
+            "presented"]], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.3290635436582345, 4.2994982408852085}, 
-           0.09160670148647594],
+          DiskBox[{4.820584431342468, 8.258604547278262}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.434285264364427, 3.579816495500892}, 0.09160670148647594],
-          "\"LaTex\""],
+          DiskBox[{5.075172267790514, 8.969737504389943}, 0.08942735681306904],
+          "\"LaTeX\""],
          Annotation[#, 
-          HoldForm["LaTex"], "Tooltip"]& ], 
+          HoldForm["LaTeX"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.608446620678838, 3.5774038258173437}, 
-           0.09160670148647594],
+          DiskBox[{5.215599500360612, 8.933578301791279}, 0.08942735681306904],
           RowBox[{"\[LeftAssociation]", 
             RowBox[{
               RowBox[{"\"Type\"", "\[Rule]", "\"Display\""}], ",", 
@@ -3476,18 +3738,20 @@ larger and more important, there aren't any other sizes to choose from."],
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.937379100596372, 4.803926559212624}, 0.09160670148647594],
+          DiskBox[{5.379376173379546, 7.401387807211994}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.514473999137346, 4.348843123365407}, 0.09160670148647594],
-          "\"LaTex\""],
+          DiskBox[{6.0749114756274665, 7.4603424077677625}, 
+           0.08942735681306904],
+          "\"LaTeX\""],
          Annotation[#, 
-          HoldForm["LaTex"], "Tooltip"]& ], 
+          HoldForm["LaTeX"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.544163830330492, 4.507187455620942}, 0.09160670148647594],
+          DiskBox[{6.0316627590832805, 7.635584772186217}, 
+           0.08942735681306904],
           RowBox[{"\[LeftAssociation]", 
             RowBox[{
               RowBox[{"\"Type\"", "\[Rule]", "\"Display\""}], ",", 
@@ -3499,243 +3763,177 @@ larger and more important, there aren't any other sizes to choose from."],
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.139956860641827, 6.057860525159122}, 0.09160670148647594],
+          DiskBox[{4.581136508721804, 8.133354965964118}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.795050376146038, 6.506546315026222}, 0.09160670148647594],
+          DiskBox[{4.83620311929772, 8.7302219988778}, 0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.8764075476521285, 6.3553928143184315}, 
-           0.09160670148647594],
+          DiskBox[{4.6553977234939765, 8.789389116898171}, 
+           0.08942735681306904],
           "\"URLs\""],
          Annotation[#, 
           HoldForm["URLs"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.390957117237612, 5.471726388758466}, 0.09160670148647594],
+          DiskBox[{3.9635963650644177, 7.037343321318895}, 
+           0.08942735681306904],
           "\"Add hyperlinks in the following ways:\""],
          Annotation[#, 
           HoldForm["Add hyperlinks in the following ways:"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.684272837492315, 3.5257723283606364}, 
-           0.09160670148647594],
+          DiskBox[{5.301104722444012, 7.7111120515840215}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.312851262600051, 2.927792878572488}, 0.09160670148647594],
+          DiskBox[{5.899561466209671, 8.148340180353653}, 0.08942735681306904],
           "\"Item\""],
          Annotation[#, 
           HoldForm["Item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{3.454665880819702, 1.7949399948569198}, 
-           0.09160670148647594],
-          "List"],
-         Annotation[#, List, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{3.107149969604401, 1.2697142309877574}, 
-           0.09160670148647594],
-          "\"A named link to\""],
-         Annotation[#, 
-          HoldForm["A named link to"], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{2.8402801028759335, 0.6325055724005191}, 
-           0.09160670148647594],
-          "MarkdownElement"],
-         Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{2.5147214841562135, 0.02188936682112974}, 
-           0.09160670148647594],
-          "Hyperlink"],
-         Annotation[#, 
-          HoldForm[Hyperlink], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{2.3903378885908486, 0.13641052334333637}, 
-           0.09160670148647594],
-          "\"MarkItDown\""],
-         Annotation[#, 
-          HoldForm["MarkItDown"], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[DiskBox[{2.6848538867592318, 0.}, 0.09160670148647594],
-          "\" http://www.markitdown.net/\""],
-         Annotation[#, 
-          HoldForm[" http://www.markitdown.net/"], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{2.969734808735848, 1.3973196449626908}, 
-           0.09160670148647594],
-          
-          "\". The easiest way to do these is to select what you want to make \
-a link and hit \""],
-         Annotation[#, 
-          HoldForm[
-          ". The easiest way to do these is to select what you want to make a \
-link and hit "], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{2.6139636124552297, 1.0290860414271767}, 
-           0.09160670148647594],
-          "MarkdownElement"],
-         Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{2.183218120571536, 0.5211401140032796}, 
-           0.09160670148647594],
-          "\"InlineCode\""],
-         Annotation[#, 
-          HoldForm["InlineCode"], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{2.0572902444368513, 0.6628371686256589}, 
-           0.09160670148647594],
-          "\"Ctrl+L\""],
-         Annotation[#, 
-          HoldForm["Ctrl+L"], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{3.276945356449117, 1.1915921928457776}, 
-           0.09160670148647594],
-          "\".\""],
-         Annotation[#, 
-          HoldForm["."], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{6.681784543613302, 3.7775351703413564}, 
-           0.09160670148647594],
-          "MarkdownElement"],
-         Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{6.998598303021172, 3.107533998705567}, 0.09160670148647594],
-          "\"Item\""],
-         Annotation[#, 
-          HoldForm["Item"], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{7.175185680652674, 2.367370516478095}, 0.09160670148647594],
-          "List"],
-         Annotation[#, List, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{7.4062242136734415, 1.7449805088929797}, 
-           0.09160670148647594],
-          "\"Another named link to\""],
-         Annotation[#, 
-          HoldForm["Another named link to"], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{7.524388739636002, 1.2736501707104857}, 
-           0.09160670148647594],
-          "MarkdownElement"],
-         Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{7.814108615006636, 0.6614253712378391}, 
-           0.09160670148647594],
-          "Hyperlink"],
-         Annotation[#, 
-          HoldForm[Hyperlink], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{7.622782418453562, 0.6132936263564464}, 
-           0.09160670148647594],
+          DiskBox[{5.949344942896135, 7.9797645531397885}, 
+           0.08942735681306904],
           RowBox[{"\[LeftAssociation]", 
             RowBox[{
-              RowBox[{"\"Label\"", "\[Rule]", "\"MarkItDown\""}], ",", 
-              
-              RowBox[{"\"Link\"", "\[Rule]", 
-                "\"http://www.markitdown.net/\""}]}], "\[RightAssociation]"}]],
+              RowBox[{"\"IndentationLevel\"", "\[Rule]", "0"}], ",", 
+              RowBox[{"\"IndentationType\"", "\[Rule]", "None"}], ",", 
+              RowBox[{"\"Content\"", "\[Rule]", 
+                RowBox[{"{", 
+                  RowBox[{"\"A named link to\"", ",", 
+                    RowBox[{"MarkdownElement", "[", 
+                    RowBox[{"Hyperlink", ",", "\"MarkItDown\"", ",", 
+                    RowBox[{"First", "[", 
+                    RowBox[{"Private`ExtractMarkdownFootnoteURL", "[", 
+                    RowBox[{"3", ",", "Private`footFile"}], "]"}], "]"}]}], 
+                    "]"}], ",", 
+                    "\". The easiest way to do these is to select what you \
+want to make a link and hit \"", ",", 
+                    RowBox[{"MarkdownElement", "[", 
+                    RowBox[{"\"InlineCode\"", ",", "\"Ctrl+L\""}], "]"}], ",",
+                     "\".\""}], "}"}]}]}], "\[RightAssociation]"}]],
          Annotation[#, 
           HoldForm[
            Association[
-           "Label" -> "MarkItDown", "Link" -> "http://www.markitdown.net/"]], 
+           "IndentationLevel" -> 0, "IndentationType" -> None, 
+            "Content" -> {"A named link to", 
+              MarkdownParse`MarkdownElement[Hyperlink, "MarkItDown", 
+               First[
+                Private`ExtractMarkdownFootnoteURL[3, Private`footFile]]], 
+              ". The easiest way to do these is to select what you want to \
+make a link and hit ", 
+              MarkdownParse`MarkdownElement["InlineCode", "Ctrl+L"], "."}]], 
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.839605240201792, 7.401064048731817}, 0.09160670148647594],
+          DiskBox[{4.085696073686163, 5.978473477983979}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.814852199908197, 8.120651907843758}, 0.09160670148647594],
+          DiskBox[{4.0240887122978295, 5.243637856416243}, 
+           0.08942735681306904],
           "\"Item\""],
          Annotation[#, 
           HoldForm["Item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.658659320776394, 9.056404109551258}, 0.09160670148647594],
-          "List"],
-         Annotation[#, List, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{5.699482437338801, 9.736088634012408}, 0.09160670148647594],
-          "\"Sometimes you want the URL : \""],
+          DiskBox[{3.8468798741191486, 5.25483943255516}, 0.08942735681306904],
+          RowBox[{"\[LeftAssociation]", 
+            RowBox[{
+              RowBox[{"\"IndentationLevel\"", "\[Rule]", "0"}], ",", 
+              RowBox[{"\"IndentationType\"", "\[Rule]", "None"}], ",", 
+              RowBox[{"\"Content\"", "\[Rule]", 
+                RowBox[{"{", 
+                  RowBox[{"\"Another named link to\"", ",", 
+                    RowBox[{"MarkdownElement", "[", 
+                    RowBox[{"Hyperlink", ",", 
+                    RowBox[{"\[LeftAssociation]", 
+                    RowBox[{
+                    RowBox[{"\"Label\"", "\[Rule]", "\"MarkItDown\""}], ",", 
+                    
+                    RowBox[{"\"Link\"", "\[Rule]", 
+                    "\"http://www.markitdown.net/\""}]}], 
+                    "\[RightAssociation]"}]}], "]"}]}], "}"}]}]}], 
+            "\[RightAssociation]"}]],
          Annotation[#, 
-          HoldForm["Sometimes you want the URL : "], "Tooltip"]& ], 
+          HoldForm[
+           Association[
+           "IndentationLevel" -> 0, "IndentationType" -> None, 
+            "Content" -> {"Another named link to", 
+              MarkdownParse`MarkdownElement[Hyperlink, 
+               Association[
+               "Label" -> "MarkItDown", "Link" -> 
+                "http://www.markitdown.net/"]]}]], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.499629713924206, 10.223999055450253}, 
-           0.09160670148647594],
+          DiskBox[{5.354933016376107, 7.074447717175338}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.503823984884105, 10.902569933208426}, 
-           0.09160670148647594],
-          "Hyperlink"],
+          DiskBox[{5.99949358008585, 6.928919793102453}, 0.08942735681306904],
+          
+          "\"Item\""],
          Annotation[#, 
-          HoldForm[Hyperlink], "Tooltip"]& ], 
+          HoldForm["Item"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.311483263957749, 10.8772325098507}, 0.09160670148647594],
-          
+          DiskBox[{6.030292630763196, 7.114280792767195}, 0.08942735681306904],
           RowBox[{"\[LeftAssociation]", 
-            RowBox[{"\"Link\"", "\[Rule]", "\"http://www.markitdown.net/\""}],
-             "\[RightAssociation]"}]],
+            RowBox[{
+              RowBox[{"\"IndentationLevel\"", "\[Rule]", "0"}], ",", 
+              RowBox[{"\"IndentationType\"", "\[Rule]", "None"}], ",", 
+              RowBox[{"\"Content\"", "\[Rule]", 
+                RowBox[{"{", 
+                  RowBox[{"\"Sometimes you want the URL : \"", ",", 
+                    RowBox[{"MarkdownElement", "[", 
+                    RowBox[{"Hyperlink", ",", 
+                    RowBox[{"\[LeftAssociation]", 
+                    
+                    RowBox[{
+                    "\"Link\"", "\[Rule]", "\"http://www.markitdown.net/\""}],
+                     "\[RightAssociation]"}]}], "]"}], ",", "\".\""}], 
+                  "}"}]}]}], "\[RightAssociation]"}]],
          Annotation[#, 
           HoldForm[
-           Association["Link" -> "http://www.markitdown.net/"]], 
+           Association[
+           "IndentationLevel" -> 0, "IndentationType" -> None, 
+            "Content" -> {"Sometimes you want the URL : ", 
+              MarkdownParse`MarkdownElement[Hyperlink, 
+               Association["Link" -> "http://www.markitdown.net/"]], "."}]], 
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.496263815824628, 9.71937970854627}, 0.09160670148647594],
-          
-          "\".\""],
-         Annotation[#, 
-          HoldForm["."], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{5.595041577566782, 4.498836413671705}, 0.09160670148647594],
+          DiskBox[{3.8897577887379375, 8.139591432337879}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.257962132411637, 3.8604357730101624}, 
-           0.09160670148647594],
+          DiskBox[{3.718942715813152, 8.760260943631815}, 0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.368033565322466, 3.965095407071648}, 0.09160670148647594],
+          DiskBox[{3.542449544116423, 8.73622349589089}, 0.08942735681306904],
+          
           "\"Horizontal rule\""],
          Annotation[#, 
           HoldForm["Horizontal rule"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.3391733177352165, 5.247885235908314}, 
-           0.09160670148647594],
+          DiskBox[{4.71120192818456, 7.067757558439377}, 0.08942735681306904],
+          
           
           "\"A horizontal rule is a dividing line drawn across the page, \
 useful for separating blocks of text.\""],
@@ -3745,348 +3943,351 @@ useful for separating blocks of text.\""],
 for separating blocks of text."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.354670870650555, 5.443444367163717}, 0.09160670148647594],
+          DiskBox[{4.088283606644217, 7.607956998751922}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.7982613814006525, 5.440843428826689}, 
-           0.09160670148647594],
+          DiskBox[{3.90487399765425, 7.938191793550881}, 0.08942735681306904],
+          
           "\"HorizontalLine\""],
          Annotation[#, 
           HoldForm["HorizontalLine"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.141963963378403, 4.890284672065186}, 0.09160670148647594],
+          DiskBox[{5.084332802366587, 7.925425854549895}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.8271991209872, 4.4721875793565475}, 0.09160670148647594],
-          
+          DiskBox[{5.497424695782309, 8.482133217666814}, 0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.876580382567813, 4.642248647007493}, 0.09160670148647594],
+          DiskBox[{5.646852820818346, 8.364745421071987}, 0.08942735681306904],
           "\"Tables\""],
          Annotation[#, 
           HoldForm["Tables"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{9.088899339010842, 5.6581536681620745}, 
-           0.09160670148647594],
+          DiskBox[{7.418951525791767, 7.109779374614819}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{9.754750855504284, 5.713485518222969}, 0.09160670148647594],
+          DiskBox[{8.085054207854531, 7.12346235292525}, 0.08942735681306904],
+          
           "\"Table\""],
          Annotation[#, 
           HoldForm["Table"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{11.994495943153051, 5.847975449135157}, 
-           0.09160670148647594],
+          DiskBox[{10.357750582734816, 7.065549686650186}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{13.083426950867253, 5.589614702821642}, 
-           0.09160670148647594],
+          DiskBox[{11.393536517246574, 7.448361366587958}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{13.525224798871628, 5.604430734677218}, 
-           0.09160670148647594],
+          DiskBox[{11.826599815857687, 7.480471783028372}, 
+           0.08942735681306904],
           "\"TableHeader\""],
          Annotation[#, 
           HoldForm["TableHeader"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{13.976821766259441, 5.285523569411651}, 
-           0.09160670148647594],
+          DiskBox[{12.23617654291298, 7.856520492010279}, 0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{14.452779146746188, 5.136658605880359}, 
-           0.09160670148647594],
+          DiskBox[{12.705868080340407, 8.08970446797311}, 0.08942735681306904],
           "\"Markdown \""],
          Annotation[#, 
           HoldForm["Markdown "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{14.376373469174224, 4.943462682856254}, 
-           0.09160670148647594],
+          DiskBox[{12.72001038795623, 7.876117668376667}, 0.08942735681306904],
           "\" Less \""],
          Annotation[#, 
           HoldForm[" Less "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{14.45776102985181, 5.336854474157462}, 0.09160670148647594],
+          DiskBox[{12.556945280211995, 8.239720650266642}, 
+           0.08942735681306904],
           "\" Pretty\""],
          Annotation[#, 
           HoldForm[" Pretty"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{13.246207494429328, 6.646486258685746}, 
-           0.09160670148647594],
+          DiskBox[{11.624074072243083, 6.3503079709769565}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{13.677248416434592, 6.868119684127845}, 
-           0.09160670148647594],
+          DiskBox[{12.051191591222935, 6.166521108587049}, 
+           0.08942735681306904],
           "\"TableAlignment\""],
          Annotation[#, 
           HoldForm["TableAlignment"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{14.350720680635867, 7.39019654991866}, 0.09160670148647594],
+          DiskBox[{12.74796259427125, 5.672019460235472}, 0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{14.96495746524387, 7.825991472327696}, 0.09160670148647594],
+          DiskBox[{13.382099178253634, 5.287821835704354}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{15.426879450359738, 8.162239429205055}, 
-           0.09160670148647594],
+          DiskBox[{13.864371216186239, 5.00122482760035}, 0.08942735681306904],
           "Center"],
          Annotation[#, 
           HoldForm[Center], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{15.048204793750136, 7.594594845886325}, 
-           0.09160670148647594],
-          "List"],
-         Annotation[#, List, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{15.561233614092359, 7.794041683695525}, 
-           0.09160670148647594],
-          "Center"],
-         Annotation[#, 
-          HoldForm[Center], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{14.80104177978826, 7.958471873035512}, 0.09160670148647594],
-          "List"],
-         Annotation[#, List, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{15.160302724056214, 8.379854516864336}, 
-           0.09160670148647594],
-          "Center"],
-         Annotation[#, 
-          HoldForm[Center], "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{14.25654186105487, 5.685757029332036}, 0.09160670148647594],
-          "List"],
-         Annotation[#, List, "Tooltip"]& ], 
-        TagBox[
-         TooltipBox[
-          DiskBox[{16.1263105086719, 5.312072812115749}, 0.09160670148647594],
+          DiskBox[{13.44782023636981, 5.53189698837753}, 0.08942735681306904],
           
+          "List"],
+         Annotation[#, List, "Tooltip"]& ], 
+        TagBox[
+         TooltipBox[
+          DiskBox[{13.970494500230046, 5.397522214518761}, 
+           0.08942735681306904],
+          "Center"],
+         Annotation[#, 
+          HoldForm[Center], "Tooltip"]& ], 
+        TagBox[
+         TooltipBox[
+          DiskBox[{13.212281880170817, 5.109551046905372}, 
+           0.08942735681306904],
+          "List"],
+         Annotation[#, List, "Tooltip"]& ], 
+        TagBox[
+         TooltipBox[
+          DiskBox[{13.592684927863829, 4.710347729628551}, 
+           0.08942735681306904],
+          "Center"],
+         Annotation[#, 
+          HoldForm[Center], "Tooltip"]& ], 
+        TagBox[
+         TooltipBox[
+          DiskBox[{12.679956752728053, 7.277177881836179}, 
+           0.08942735681306904],
+          "List"],
+         Annotation[#, List, "Tooltip"]& ], 
+        TagBox[
+         TooltipBox[
+          DiskBox[{14.678299615719123, 7.298073846990089}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{16.601930369320705, 5.173352181391354}, 
-           0.09160670148647594],
+          DiskBox[{15.172808587117853, 7.239177081156984}, 
+           0.08942735681306904],
           "\"TableRow\""],
          Annotation[#, 
           HoldForm["TableRow"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{17.88182591938794, 4.987505086175188}, 0.09160670148647594],
+          DiskBox[{16.562080784186325, 7.352107631196526}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{18.326578673143086, 4.286656296831802}, 
-           0.09160670148647594],
+          DiskBox[{17.35744497484311, 7.894579556275598}, 0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{18.399878671634553, 3.6228244216129557}, 
-           0.09160670148647594],
+          DiskBox[{17.946121157792412, 8.412031524343655}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{18.87985974177957, 3.3800755105404074}, 
-           0.09160670148647594],
+          DiskBox[{18.025096789185067, 8.815799843250224}, 
+           0.08942735681306904],
           "Italic"],
          Annotation[#, 
           HoldForm[Italic], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{18.722578751943498, 3.228727360308493}, 
-           0.09160670148647594],
+          DiskBox[{18.443463331544596, 8.641053427095034}, 
+           0.08942735681306904],
           "\"Still\""],
          Annotation[#, 
           HoldForm["Still"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{18.760225271280977, 4.112087582315865}, 
-           0.09160670148647594],
+          DiskBox[{17.754906225398877, 8.069581115799954}, 
+           0.08942735681306904],
           "\" \""],
          Annotation[#, 
           HoldForm[" "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{19.081692850008427, 4.719460846573154}, 
-           0.09160670148647594],
+          DiskBox[{17.801829937894606, 7.423051632780853}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{19.5864351442499, 4.740294720429076}, 0.09160670148647594],
-          
+          DiskBox[{18.28252464999853, 7.317974591134674}, 0.08942735681306904],
           "\" \""],
          Annotation[#, 
           HoldForm[" "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{19.993513056435074, 4.509212822729737}, 
-           0.09160670148647594],
+          DiskBox[{18.753388031137273, 7.496498712546315}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{20.48042516212634, 4.273986713374869}, 0.09160670148647594],
+          DiskBox[{19.318205823177887, 7.427700684159899}, 
+           0.08942735681306904],
           "\"InlineCode\""],
          Annotation[#, 
           HoldForm["InlineCode"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{20.55050563870432, 4.492726373656442}, 0.09160670148647594],
+          DiskBox[{19.2979190610764, 7.650153558212355}, 0.08942735681306904],
+          
           "\"renders\""],
          Annotation[#, 
           HoldForm["renders"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{19.536661352616004, 4.504855729254667}, 
-           0.09160670148647594],
+          DiskBox[{18.277414488260785, 7.564422573555159}, 
+           0.08942735681306904],
           "\" \""],
          Annotation[#, 
           HoldForm[" "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{18.90791204229512, 5.3081651696230185}, 
-           0.09160670148647594],
+          DiskBox[{17.54339301339985, 6.892331435279436}, 0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{19.36029656457787, 5.453647043822258}, 0.09160670148647594],
+          DiskBox[{17.948990555845963, 6.6653304570738285}, 
+           0.08942735681306904],
           "\" \""],
          Annotation[#, 
           HoldForm[" "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{19.768931526691414, 5.553077104704037}, 
-           0.09160670148647594],
+          DiskBox[{18.367848635722588, 6.529501908061927}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{20.262660293614317, 5.785318096162183}, 
-           0.09160670148647594],
+          DiskBox[{18.904074227155007, 6.430588328351384}, 
+           0.08942735681306904],
           "Bold"],
          Annotation[#, 
           HoldForm[Bold], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{20.322540446778728, 5.581380811800349}, 
-           0.09160670148647594],
+          DiskBox[{18.812290132294358, 6.219591427664511}, 
+           0.08942735681306904],
           "\"nicely\""],
          Annotation[#, 
           HoldForm["nicely"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{15.404884425927104, 5.939548741048312}, 
-           0.09160670148647594],
+          DiskBox[{13.738809377648028, 7.698844398919509}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{15.853339601214312, 5.980434133678887}, 
-           0.09160670148647594],
+          DiskBox[{14.173176687422405, 7.805146146232906}, 
+           0.08942735681306904],
           "\"TableRow\""],
          Annotation[#, 
           HoldForm["TableRow"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{16.37340843121873, 6.198975414238484}, 0.09160670148647594],
+          DiskBox[{14.599485910465493, 8.114979467785288}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{16.91066054533658, 6.347567429771956}, 0.09160670148647594],
+          DiskBox[{15.077530502355959, 8.348258233817022}, 
+           0.08942735681306904],
           "\"1 \""],
          Annotation[#, 
           HoldForm["1 "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{16.79120245003045, 6.505008688785374}, 0.09160670148647594],
+          DiskBox[{15.099379418990882, 8.13765055103096}, 0.08942735681306904],
           "\" 2 \""],
          Annotation[#, 
           HoldForm[" 2 "], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{16.879230153756517, 6.150820431473319}, 
-           0.09160670148647594],
+          DiskBox[{14.926474803436285, 8.487059103490683}, 
+           0.08942735681306904],
           "\" 3\""],
          Annotation[#, 
           HoldForm[" 3"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.8310361187147555, 6.422228174054945}, 
-           0.09160670148647594],
+          DiskBox[{4.563025784735975, 6.010790009338498}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.803974302277873, 7.042779731220693}, 0.09160670148647594],
+          DiskBox[{4.622003179358713, 5.278166315591998}, 0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.630950132080928, 7.010483504686625}, 0.09160670148647594],
+          DiskBox[{4.780314972936978, 5.332430730761911}, 0.08942735681306904],
           "\"Images\""],
          Annotation[#, 
           HoldForm["Images"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.728944032849775, 5.251036287475866}, 0.09160670148647594],
+          DiskBox[{4.582379184060554, 6.84028067348457}, 0.08942735681306904],
+          
           "\"Markdown can also contain images.\""],
          Annotation[#, 
           HoldForm["Markdown can also contain images."], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{5.14194656442141, 4.996842747640085}, 0.09160670148647594],
+          DiskBox[{5.56179177529301, 6.960095542868889}, 0.08942735681306904],
           
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.641933876733187, 4.636066064936365}, 0.09160670148647594],
+          DiskBox[{6.319290483558865, 6.756711667351094}, 0.08942735681306904],
           "Hyperlink"],
          Annotation[#, 
           HoldForm[Hyperlink], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{4.539258376293946, 4.771789138048413}, 0.09160670148647594],
+          DiskBox[{6.34895933651958, 6.927662351992212}, 0.08942735681306904],
+          
           RowBox[{"\[LeftAssociation]", 
             RowBox[{
               
@@ -4108,31 +4309,31 @@ ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
 format&fit=crop&w=564&q=80"]], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{6.854856507588332, 6.383517809740147}, 0.09160670148647594],
+          DiskBox[{4.462416025742012, 8.408339689573438}, 0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.424924504047318, 6.914449688305881}, 0.09160670148647594],
+          DiskBox[{4.630940593482092, 9.189259183008252}, 0.08942735681306904],
           "\"H2\""],
          Annotation[#, 
           HoldForm["H2"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.303481292047528, 7.00989529179726}, 0.09160670148647594],
-          
+          DiskBox[{4.459584151649697, 9.210512105209585}, 0.08942735681306904],
           "\"Last\""],
          Annotation[#, 
           HoldForm["Last"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.088444262246059, 7.5990565704365975}, 
-           0.09160670148647594],
+          DiskBox[{2.1188045885925337, 8.267045086961648}, 
+           0.08942735681306904],
           "List"],
          Annotation[#, List, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.258424745611117, 8.273056141853917}, 0.09160670148647594],
+          DiskBox[{1.6060800811142704, 8.770802116210893}, 
+           0.08942735681306904],
           
           "\"There's actually a lot more to Markdown than this. See the \
 official\""],
@@ -4142,63 +4343,68 @@ official\""],
 official"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.882332617913469, 8.725228223018357}, 0.09160670148647594],
+          DiskBox[{0.9576594043512472, 9.104587133403088}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{8.3921723552855, 9.182230608762898}, 0.09160670148647594],
+          DiskBox[{0.49396679163982515, 9.63897892166591}, 
+           0.08942735681306904],
           "Hyperlink"],
          Annotation[#, 
           HoldForm[Hyperlink], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{8.143644861639057, 9.371030983689465}, 0.09160670148647594],
+          DiskBox[{0.29415859947790324, 9.38648654402881}, 
+           0.08942735681306904],
           "\"introduction\""],
          Annotation[#, 
           HoldForm["introduction"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{8.295208090698603, 9.315566631685783}, 0.09160670148647594],
+          DiskBox[{0.3472636193434253, 9.5441012676411}, 0.08942735681306904],
+          
           "\" http://daringfireball.net/projects/markdown/basics\""],
          Annotation[#, 
           HoldForm[" http://daringfireball.net/projects/markdown/basics"], 
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.578019246672767, 8.1019804414447}, 0.09160670148647594],
+          DiskBox[{1.488288563697191, 8.631170747892225}, 0.08942735681306904],
           "\" and\""],
          Annotation[#, 
           HoldForm[" and"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.447227826639867, 8.937988501721424}, 0.09160670148647594],
+          DiskBox[{0.7325419314125767, 8.648535863408286}, 
+           0.08942735681306904],
           "MarkdownElement"],
          Annotation[#, MarkdownParse`MarkdownElement, "Tooltip"]& ], 
         TagBox[
-         TooltipBox[
-          DiskBox[{7.627752798759985, 9.649269414944783}, 0.09160670148647594],
+         TooltipBox[DiskBox[{0., 8.841488439118816}, 0.08942735681306904],
           "Hyperlink"],
          Annotation[#, 
           HoldForm[Hyperlink], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.759925934285199, 9.55358691871287}, 0.09160670148647594],
-          
+          DiskBox[{0.08998200902993947, 8.978340043729677}, 
+           0.08942735681306904],
           "\"syntax\""],
          Annotation[#, 
           HoldForm["syntax"], "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.46487511344125, 9.625468670516435}, 0.09160670148647594],
-          
+          DiskBox[{0.01705779188055523, 8.674670131801706}, 
+           0.08942735681306904],
           "\" http://daringfireball.net/projects/markdown/syntax\""],
          Annotation[#, 
           HoldForm[" http://daringfireball.net/projects/markdown/syntax"], 
           "Tooltip"]& ], 
         TagBox[
          TooltipBox[
-          DiskBox[{7.433023185392041, 8.212511387964923}, 0.09160670148647594],
+          DiskBox[{1.4276796884090084, 8.461287449182096}, 
+           0.08942735681306904],
           
           "\" for more information. Be aware that this document is not using \
 the official implementation, and there may be subtle differences in rendering \
@@ -4218,17 +4424,18 @@ on other platforms."], "Tooltip"]& ]}}],
  CellChangeTimes->{{3.817338487986231*^9, 3.817338514810109*^9}, {
    3.8173385576439323`*^9, 3.817338564302596*^9}, {3.817338623507262*^9, 
    3.817338642412307*^9}, {3.817338676901799*^9, 3.817338736123383*^9}, 
-   3.81734108063984*^9, 3.8173468383658752`*^9, 3.817416495382346*^9},
- CellLabel->"Out[7]=",ExpressionUUID->"df9c4cdf-7b45-445d-a0a0-0e19bf50fbee"]
+   3.81734108063984*^9, 3.8173468383658752`*^9, 3.817416495382346*^9, 
+   3.83978660919948*^9},
+ CellLabel->"Out[12]=",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]]
 },
-WindowSize->{640, 688},
-WindowMargins->{{Automatic, 0}, {Automatic, 0}},
+WindowSize->{1440, 847},
+WindowMargins->{{0, Automatic}, {Automatic, 0}},
 TaggingRules->{
  "WelcomeScreenSettings" -> {"FEStarting" -> False}, "TryRealOnly" -> False},
-FrontEndVersion->"12.2 for Mac OS X x86 (64-bit) (December 12, 2020)",
+FrontEndVersion->"12.3 for Mac OS X ARM (64-bit) (June 24, 2021)",
 StyleDefinitions->"Default.nb",
 ExpressionUUID->"e0e2896d-ee92-43bf-bc77-38b0ba2a744d"
 ]
@@ -4248,42 +4455,48 @@ Cell[580, 22, 261, 4, 98, "Title",ExpressionUUID->"b7946855-acef-475d-bca3-4f6aa
 Cell[844, 28, 336, 5, 62, "Abstract",ExpressionUUID->"41f6fde2-3312-478f-b2c8-ff97b1cd3e62"],
 Cell[1183, 35, 249, 4, 35, "Text",ExpressionUUID->"ae62ea4f-43d4-4edf-903f-316f87708814"],
 Cell[1435, 41, 160, 3, 38, "CodeText",ExpressionUUID->"fea4a3a1-ea63-4863-a1c5-7652c6364503"],
-Cell[1598, 46, 176, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
-Cell[1777, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
-Cell[1967, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
-Cell[2235, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
-Cell[2517, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
-Cell[2734, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
-Cell[2929, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
+Cell[1598, 46, 177, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+Cell[1778, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
+Cell[1968, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
+Cell[2236, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
+Cell[2518, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
+Cell[2735, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
+Cell[2930, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
 Cell[CellGroupData[{
-Cell[3347, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
-Cell[3561, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
+Cell[3348, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
+Cell[3562, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
 Cell[CellGroupData[{
-Cell[3773, 103, 536, 12, 52, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
-Cell[4312, 117, 5424, 134, 407, "Output",ExpressionUUID->"a546dc40-7ffc-4fb1-946d-ce4e69710ee7"]
+Cell[3774, 103, 536, 12, 30, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
+Cell[4313, 117, 5901, 143, 403, "Output",ExpressionUUID->"9d30d1e1-3b38-4327-b7fa-5f15a0c5141e"]
 }, Open  ]]
-}, Closed]],
+}, Open  ]],
 Cell[CellGroupData[{
-Cell[9785, 257, 265, 4, 53, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
-Cell[10053, 263, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
-Cell[10707, 278, 511, 9, 30, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
+Cell[10263, 266, 265, 4, 67, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
+Cell[10531, 272, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
 Cell[CellGroupData[{
-Cell[11243, 291, 264, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
-Cell[11510, 298, 14595, 350, 2477, "Output",ExpressionUUID->"80983d5b-79cc-41b1-b3ea-8ac508483630"]
+Cell[11207, 289, 249, 4, 30, "Input",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
+Cell[11459, 295, 3837, 50, 2429, "Output",ExpressionUUID->"1c788981-27b2-4fe6-a8a9-38507ecb363b"]
+}, Open  ]],
+Cell[15311, 348, 511, 9, 30, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
+Cell[CellGroupData[{
+Cell[15847, 361, 264, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
+Cell[16114, 368, 17426, 406, 1417, "Output",ExpressionUUID->"1851928c-a621-40b8-b5d9-bcd902336aef"]
+}, Open  ]],
+Cell[33555, 777, 427, 11, 35, "Text",ExpressionUUID->"fd11d7bb-32c7-4cc0-b0ef-780fc0134e6d"],
+Cell[33985, 790, 1151, 24, 73, "Input",ExpressionUUID->"b263aba7-97b0-4acf-882c-d77f77a17c66"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[35173, 819, 157, 3, 67, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
+Cell[CellGroupData[{
+Cell[35355, 826, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
+Cell[35486, 829, 35105, 635, 63, "Output",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
 }, Open  ]]
-}, Closed]],
+}, Open  ]],
 Cell[CellGroupData[{
-Cell[26154, 654, 157, 3, 53, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
+Cell[70640, 1470, 213, 4, 67, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
 Cell[CellGroupData[{
-Cell[26336, 661, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
-Cell[26467, 664, 35107, 637, 63, "Output",ExpressionUUID->"0d6ee9b0-1835-4dd4-b358-105875962f77"]
-}, Open  ]]
-}, Closed]],
-Cell[CellGroupData[{
-Cell[61623, 1307, 213, 4, 53, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
-Cell[CellGroupData[{
-Cell[61861, 1315, 503, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
-Cell[62367, 1326, 128723, 2895, 250, "Output",ExpressionUUID->"df9c4cdf-7b45-445d-a0a0-0e19bf50fbee"]
+Cell[70878, 1478, 504, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
+Cell[71385, 1489, 132096, 2939, 301, "Output",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]]

--- a/Parser/MarkdownParserDemo.nb
+++ b/Parser/MarkdownParserDemo.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    248845,       5285]
-NotebookOptionsPosition[    245100,       5216]
-NotebookOutlinePosition[    245587,       5234]
-CellTagsIndexPosition[    245544,       5231]
+NotebookDataLength[    245180,       5241]
+NotebookOptionsPosition[    241439,       5172]
+NotebookOutlinePosition[    241926,       5190]
+CellTagsIndexPosition[    241883,       5187]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -46,7 +46,7 @@ Cell["Quit the kernel", "CodeText",
 
 Cell[BoxData["Quit"], "Input",
  CellChangeTimes->{{3.817239754310732*^9, 3.8172397548456573`*^9}},
- CellLabel->"In[5]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+ CellLabel->"In[13]:=",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
 
 Cell["Install the packages again from the Menu:", "Text",
  CellChangeTimes->{{3.8174165987397127`*^9, 
@@ -266,8 +266,8 @@ Cell[BoxData[
    3.817389589946957*^9, 3.817423982038066*^9, 3.8397853572118587`*^9, {
    3.839785419382757*^9, 3.8397854364402733`*^9}, {3.839785527027009*^9, 
    3.839785540844495*^9}, 3.839786014047813*^9, 3.8397862448168993`*^9, 
-   3.845226378341282*^9},
- CellLabel->"Out[3]=",ExpressionUUID->"3b4e9d5f-2ca3-4524-b7a9-f0828e41a3fe"]
+   3.845226378341282*^9, 3.84522716739851*^9},
+ CellLabel->"Out[3]=",ExpressionUUID->"9e8c8536-6d50-4b44-b5a1-3a64d5972403"]
 }, Open  ]]
 }, Open  ]],
 
@@ -294,73 +294,15 @@ Cell[BoxData[
    3.8173897935513268`*^9, 3.817389831975668*^9}},
  CellLabel->"In[4]:=",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
 
-Cell[CellGroupData[{
-
 Cell[BoxData[
- RowBox[{"Import", "[", 
-  RowBox[{"filePath", ",", "\"\<Text\>\""}], "]"}]], "Input",
+ RowBox[{
+  RowBox[{"Import", "[", 
+   RowBox[{"filePath", ",", "\"\<Text\>\""}], "]"}], ";"}]], "Input",
  CellChangeTimes->{{3.839786671641347*^9, 3.8397867032127323`*^9}, {
-  3.845226422574849*^9, 3.845226424824779*^9}},
+   3.845226422574849*^9, 3.845226424824779*^9}, 3.845227179074463*^9},
  CellLabel->"In[6]:=",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
 
-Cell[BoxData["\<\"# An exhibit of Markdown\\n\\nThis note demonstrates some \
-of what [Markdown][1] is capable of doing.\\n\\n_Note: Feel free to play with \
-this page. Unlike regular notes, this doesn't automatically save \
-itself._\\n\\n## Basic formatting\\n\\nWrite Paragraphs like so. A paragraph \
-is the basic block of Markdown. A paragraph is what text will turn into when \
-there is no reason it should become anything else.\\n\\nBlank lines separate \
-paragraphs. Markdown supports _italic_ and **bold** formatting.\\n\\nLines \
-can have nested styling as well, like _a **bold** in an italic_.\\n\\n## \
-Lists\\n\\n### Ordered list with Tabs\\n\\n1. Item 1\\n2. A second item\\n3. \
-Number 3\\n4. \:2163\\n\\t5. A nested ordered item\\n\\n### Ordered list with \
-Spaces\\n\\n1. First item\\n  2. First item's subitem\\n  3. First item's 2nd \
-subitem\\n    4. 2nd item's subitem\\n\\n_Note: the fourth item uses the \
-Unicode character for [Roman numeral four][2]._\\n\\n### Unordered \
-list\\n\\n* An item\\n* Another item\\n* Yet another item\\n\\t* A nested \
-unordered item with tabs\\n* And there's more...\\n\\n* unordered list with \
-spaces\\n  * list item with space indentation\\n    * another list item with \
-space indentation\\n\\n## Paragraph modifiers\\n\\n### Code block\\n\\n    \
-Code blocks are useful for people who look at code or for clarity of plain \
-text content. As you can see, it uses a fixed-width font.\\n\\nYou can also \
-make `inline code` to add insert code block formatting anywhere.\\n\\n### \
-Quote\\n\\n> Here is a quote. What this is should be self explanatory. Quotes \
-are automatically indented when they are used.\\n\\n## Headings\\n\\nMarkdown \
-supports six levels of headings; corresponding with the six levels of HTML \
-headings. You've probably noticed them already in the page. Each level down \
-uses one more hash character.\\n\\n### Headings _can_ also contain \
-**formatting**\\n\\n### They can even contain `inline code`\\n\\nOf course, \
-demonstrating what headings look like messes up the structure of the page.\\n\
-\\nI don't recommend using more than three or four levels of headings here, \
-because, when you're smallest heading isn't too small, and you're largest \
-heading isn't too big, and you want each size up to look noticeably larger \
-and more important, there aren't any other sizes to choose from.\\n\\n## \
-LaTex\\n\\nLaTeX is also supported:\\n\\n* inline\\n\\n\\\\(a^2 + b^2 = c^2\\\
-\\)\\n\\n$ a^2 + b^2 = c^2 $\\n\\n* presented\\n\\n\\\\[ a^n + b^n = c^n \
-\\\\]\\n\\n$$ a^2 + b^2 = c^2 $$\\n\\n\\n## URLs\\n\\nAdd hyperlinks in the \
-following ways:\\n\\n* A named link to [MarkItDown][3]. The easiest way to do \
-these is to select what you want to make a link and hit `Ctrl+L`.\\n* Another \
-named link to [MarkItDown](http://www.markitdown.net/)\\n* Sometimes you want \
-the URL : <http://www.markitdown.net/>.\\n\\n## Horizontal rule\\n\\nA \
-horizontal rule is a dividing line drawn across the page, useful for \
-separating blocks of text.\\n\\n---\\n\\n## Tables\\n\\nMarkdown | Less | \
-Pretty\\n--- | --- | ---\\n*Still* | `renders` | **nicely**\\n1 | 2 | \
-3\\n\\n## Images\\n\\nMarkdown can also contain images.\\n![Streetview of \
-Palm Trees by Brandon \
-Erlinger-Ford](https://images.unsplash.com/photo-1564889998041-0dacc0706a0f?\
-ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=\
-format&fit=crop&w=564&q=80)\\n\\n## Last\\n\\nThere's actually a lot more to \
-Markdown than this. See the official [introduction][4] and [syntax][5] for \
-more information. Be aware that this document is not using the official \
-implementation, and there may be subtle differences in rendering on other \
-platforms.\\n\\n\\n  [1]: http://daringfireball.net/projects/markdown/\\n  \
-[2]: http://www.fileformat.info/info/unicode/char/2163/index.htm\\n  [3]: \
-http://www.markitdown.net/\\n  [4]: \
-http://daringfireball.net/projects/markdown/basics\\n  [5]: \
-http://daringfireball.net/projects/markdown/syntax\"\>"], "Output",
- CellChangeTimes->{{3.839786672681287*^9, 3.839786703609291*^9}, {
-  3.8452264115314407`*^9, 3.845226425375347*^9}},
- CellLabel->"Out[6]=",ExpressionUUID->"35f09d72-a78d-43d5-8a17-d90e59057af6"]
-}, Closed]],
+Cell[CellGroupData[{
 
 Cell[BoxData[
  RowBox[{
@@ -371,7 +313,21 @@ Cell[BoxData[
    3.8171704049186897`*^9}, 3.8172358431384687`*^9, {3.817240946833456*^9, 
    3.81724094888334*^9}, 3.8172413585269203`*^9, {3.81734384974724*^9, 
    3.817343850827291*^9}},
- CellLabel->"In[9]:=",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
+ CellLabel->"In[7]:=",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
+
+Cell[BoxData[
+ RowBox[{
+  TagBox["\<\"FootFile\"\>",
+   "EchoLabel"], 
+  "  ", "\<\"[1]: http://daringfireball.net/projects/markdown/\\n[2]: \
+http://www.fileformat.info/info/unicode/char/2163/index.htm\\n[3]: \
+http://www.markitdown.net/\\n[4]: \
+http://daringfireball.net/projects/markdown/basics\\n[5]: \
+http://daringfireball.net/projects/markdown/syntax\"\>"}]], "Echo",
+ CellChangeTimes->{
+  3.845227180636941*^9},ExpressionUUID->"605c8bc1-821f-457c-a598-\
+e40741ffbb34"]
+}, Open  ]],
 
 Cell[CellGroupData[{
 
@@ -380,7 +336,7 @@ Cell[BoxData[
   RowBox[{"mdp", ",", 
    RowBox[{"Frame", "\[Rule]", "All"}]}], "]"}]], "Input",
  CellChangeTimes->{{3.817333311218748*^9, 3.817333316916204*^9}},
- CellLabel->"In[11]:=",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
+ CellLabel->"In[8]:=",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
 
 Cell[BoxData[
  TagBox[GridBox[{
@@ -929,8 +885,8 @@ in rendering on other platforms.\"\>"}], "}"}]}
    3.8173454763293324`*^9, 3.817346050239132*^9, 3.81734662850709*^9, 
    3.817346763411755*^9, 3.817389840621285*^9, 3.8174164489123363`*^9, 
    3.83978561192607*^9, {3.839786021507169*^9, 3.839786026115018*^9}, 
-   3.839786250526957*^9, 3.8452264595099916`*^9},
- CellLabel->"Out[11]=",ExpressionUUID->"8be56051-5855-446e-af66-6707c0c615b9"]
+   3.839786250526957*^9, 3.8452264595099916`*^9, 3.845227189799056*^9},
+ CellLabel->"Out[8]=",ExpressionUUID->"f3c27957-ee9c-4018-9df1-23406b00f1a6"]
 }, Open  ]],
 
 Cell[TextData[{
@@ -5214,7 +5170,7 @@ on other platforms."], "Tooltip"]& ]}}],
 }, Open  ]]
 }, Open  ]]
 },
-WindowSize->{1696, 1387},
+WindowSize->{2560, 1387},
 WindowMargins->{{0, Automatic}, {Automatic, 0}},
 TaggingRules->{
  "WelcomeScreenSettings" -> {"FEStarting" -> False}, "TryRealOnly" -> False},
@@ -5238,52 +5194,52 @@ Cell[580, 22, 261, 4, 98, "Title",ExpressionUUID->"b7946855-acef-475d-bca3-4f6aa
 Cell[844, 28, 336, 5, 62, "Abstract",ExpressionUUID->"41f6fde2-3312-478f-b2c8-ff97b1cd3e62"],
 Cell[1183, 35, 249, 4, 35, "Text",ExpressionUUID->"ae62ea4f-43d4-4edf-903f-316f87708814"],
 Cell[1435, 41, 160, 3, 38, "CodeText",ExpressionUUID->"fea4a3a1-ea63-4863-a1c5-7652c6364503"],
-Cell[1598, 46, 176, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
-Cell[1777, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
-Cell[1967, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
-Cell[2235, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
-Cell[2517, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
-Cell[2734, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
-Cell[2929, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
+Cell[1598, 46, 177, 2, 30, "Input",ExpressionUUID->"14e54866-d7f3-4f17-9074-d8f159484569"],
+Cell[1778, 50, 187, 3, 35, "Text",ExpressionUUID->"f5f4754d-cb7f-445c-b6aa-21d386c647ab"],
+Cell[1968, 55, 265, 4, 32, "Item",ExpressionUUID->"1b196ee9-d5d1-46dc-8ca0-049537859d6f"],
+Cell[2236, 61, 279, 6, 32, "Item",ExpressionUUID->"328c2086-ad04-4777-8fca-349330ab56d6"],
+Cell[2518, 69, 214, 4, 35, "Text",ExpressionUUID->"4d05c24d-9b3c-450e-8869-e15918e4ea41"],
+Cell[2735, 75, 192, 3, 38, "CodeText",ExpressionUUID->"8d0676c6-1170-4ab4-9427-52aa2d5bd45e"],
+Cell[2930, 80, 393, 6, 52, "Input",ExpressionUUID->"512dcb97-052f-434b-86d0-eedcfeef80ee"],
 Cell[CellGroupData[{
-Cell[3347, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
-Cell[3561, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
+Cell[3348, 90, 211, 4, 67, "Section",ExpressionUUID->"ed8a7d53-f2bf-4ccf-ac2c-0bb641bd7da7"],
+Cell[3562, 96, 187, 3, 35, "Text",ExpressionUUID->"f351d147-2c71-4e75-8503-4812d9fd3995"],
 Cell[CellGroupData[{
-Cell[3773, 103, 536, 12, 30, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
-Cell[4312, 117, 6329, 152, 403, "Output",ExpressionUUID->"3b4e9d5f-2ca3-4524-b7a9-f0828e41a3fe"]
+Cell[3774, 103, 536, 12, 30, "Input",ExpressionUUID->"f1fcf8ce-29d8-40fc-99c1-c93ff96ce718"],
+Cell[4313, 117, 6350, 152, 403, "Output",ExpressionUUID->"9e8c8536-6d50-4b44-b5a1-3a64d5972403"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[10690, 275, 265, 4, 67, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
-Cell[10958, 281, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
+Cell[10712, 275, 265, 4, 67, "Section",ExpressionUUID->"b3b2a78c-44c3-460b-86ab-b0b33931b39c"],
+Cell[10980, 281, 651, 13, 30, "Input",ExpressionUUID->"eb165041-5cf3-44fe-84d0-1ed19d05bc91"],
+Cell[11634, 296, 337, 6, 30, "Input",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
 Cell[CellGroupData[{
-Cell[11634, 298, 295, 5, 30, "Input",ExpressionUUID->"a972bbb6-220f-477c-9519-23652026c73b"],
-Cell[11932, 305, 4222, 56, 2639, "Output",ExpressionUUID->"35f09d72-a78d-43d5-8a17-d90e59057af6"]
-}, Closed]],
-Cell[16169, 364, 511, 9, 26, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
-Cell[CellGroupData[{
-Cell[16705, 377, 265, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
-Cell[16973, 384, 24025, 548, 1547, "Output",ExpressionUUID->"8be56051-5855-446e-af66-6707c0c615b9"]
-}, Open  ]],
-Cell[41013, 935, 396, 10, 35, "Text",ExpressionUUID->"fd11d7bb-32c7-4cc0-b0ef-780fc0134e6d"],
-Cell[41412, 947, 1151, 24, 73, "Input",ExpressionUUID->"b263aba7-97b0-4acf-882c-d77f77a17c66"]
+Cell[11996, 306, 511, 9, 30, "Input",ExpressionUUID->"eacdcb92-3bd4-49f3-8e4a-d8e4f3c127e1"],
+Cell[12510, 317, 477, 11, 101, "Echo",ExpressionUUID->"605c8bc1-821f-457c-a598-e40741ffbb34"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[42600, 976, 157, 3, 67, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
-Cell[CellGroupData[{
-Cell[42782, 983, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
-Cell[42913, 986, 35105, 635, 63, "Output",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
+Cell[13024, 333, 264, 5, 30, "Input",ExpressionUUID->"81c3bc60-b0c4-414c-a59a-0ad5ebeb3a3c"],
+Cell[13291, 340, 24046, 548, 1431, "Output",ExpressionUUID->"f3c27957-ee9c-4018-9df1-23406b00f1a6"]
+}, Open  ]],
+Cell[37352, 891, 396, 10, 35, "Text",ExpressionUUID->"fd11d7bb-32c7-4cc0-b0ef-780fc0134e6d"],
+Cell[37751, 903, 1151, 24, 73, "Input",ExpressionUUID->"b263aba7-97b0-4acf-882c-d77f77a17c66"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[78055, 1626, 129, 1, 30, "Input",ExpressionUUID->"d8839fb1-a010-4533-9172-beee3a24edf2"],
-Cell[78187, 1629, 33983, 618, 63, "Output",ExpressionUUID->"03a2d32d-c89c-4f8a-83d7-c9ecf1566c64"]
+Cell[38939, 932, 157, 3, 67, "Section",ExpressionUUID->"b146c287-093e-4ce4-bf8b-fc1c63394988"],
+Cell[CellGroupData[{
+Cell[39121, 939, 128, 1, 30, "Input",ExpressionUUID->"6f9dcc92-bd17-4872-a306-71c269a07483"],
+Cell[39252, 942, 35105, 635, 63, "Output",ExpressionUUID->"b7177d85-3de0-49d7-93cb-15686833a2a1"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[74394, 1582, 129, 1, 30, "Input",ExpressionUUID->"d8839fb1-a010-4533-9172-beee3a24edf2"],
+Cell[74526, 1585, 33983, 618, 63, "Output",ExpressionUUID->"03a2d32d-c89c-4f8a-83d7-c9ecf1566c64"]
 }, Open  ]]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[112219, 2253, 213, 4, 67, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
+Cell[108558, 2209, 213, 4, 67, "Section",ExpressionUUID->"4f666e40-40ae-47f6-84f5-e0c92279d12d"],
 Cell[CellGroupData[{
-Cell[112457, 2261, 504, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
-Cell[112964, 2272, 132096, 2939, 301, "Output",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
+Cell[108796, 2217, 504, 9, 30, "Input",ExpressionUUID->"5a0df57e-3ad2-41a8-b185-d42a6cf33609"],
+Cell[109303, 2228, 132096, 2939, 301, "Output",ExpressionUUID->"d64edc38-07fc-4033-ab24-f5b7ce98d56e"]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]]

--- a/Parser/MarkdownParserTests.wl
+++ b/Parser/MarkdownParserTests.wl
@@ -131,6 +131,27 @@ f[y]:=3"|>],"\n"},TestID->"CodeBlockTest2"],
 		FixedPoint[MarkdownParser,"[The first footnote][1] was there and here's [the second footnote][2]"],
 		{MarkdownElement[Hyperlink,"The first footnote",MarkdownElement["FootnoteReference",{1}]]," was there and here's",MarkdownElement[Hyperlink,"the second footnote",MarkdownElement["FootnoteReference",{2}]]},
 		TestID -> "FoonoteTest1"
+		],
+	(* LIST ITEMS *)
+	VerificationTest[
+		FixedPoint[MarkdownParser,"* This is an unordered item"],
+		MarkdownElement["Item",<|"Type" -> "Unordered", "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> "This is an unordered item"|>],
+		TestID -> "UnorderedItemTest1"
+		],
+	VerificationTest[
+		FixedPoint[MarkdownParser,"  * here is an unordered sub item"],
+		MarkdownElement["Item",<|"Type" -> "Unordered", "IndentationLevel" -> 1, "IndentationType" -> "Whitespace", "Content" -> "here is an unordered sub item"|>],
+		TestID -> "UnorderedItemTest2"
+		],
+	VerificationTest[
+		FixedPoint[MarkdownParser,"1. This is an ordered item"],
+		MarkdownElement["Item", <|"Type" -> "Ordered", "IndentationLevel" -> 0, "IndentationType" -> None, "Content" -> "This is an ordered item"|>],
+		TestID -> "OrderedItemTest1"
+		],
+	VerificationTest[
+		FixedPoint[MarkdownParser,"  1. here is an ordered sub item"],
+		MarkdownElement["Item", <|"Type" -> "Ordered", "IndentationLevel" -> 1, "IndentationType" -> "Whitespace", "Content" -> "here is an ordered sub item"|>],
+		TestID -> "OrderedItemTest2"
 		]
 }
 )

--- a/Parser/test.md
+++ b/Parser/test.md
@@ -14,12 +14,20 @@ Lines can have nested styling as well, like _a **bold** in an italic_.
 
 ## Lists
 
-### Ordered list
+### Ordered list with Tabs
 
 1. Item 1
 2. A second item
 3. Number 3
 4. Ⅳ
+	5. A nested ordered item
+
+### Ordered list with Spaces
+
+1. First item
+  2. First item's subitem
+  3. First item's 2nd subitem
+    4. 2nd item's subitem
 
 _Note: the fourth item uses the Unicode character for [Roman numeral four][2]._
 
@@ -28,7 +36,12 @@ _Note: the fourth item uses the Unicode character for [Roman numeral four][2]._
 * An item
 * Another item
 * Yet another item
+	* A nested unordered item with tabs
 * And there's more...
+
+* unordered list with spaces
+  * list item with space indentation
+    * another list item with space indentation
 
 ## Paragraph modifiers
 
@@ -56,7 +69,7 @@ I don't recommend using more than three or four levels of headings here, because
 
 ## LaTex
 
-LaTex is also supported:
+LaTeX is also supported:
 
 * inline
 


### PR DESCRIPTION
* Added IndentationLevel and IndentationType to Unordered list item MarkdownElements.
* Ordered list items still need IndentationLevel/Type support (will add to this PR)